### PR TITLE
grains.t fixes

### DIFF
--- a/grains/cases.json
+++ b/grains/cases.json
@@ -1,49 +1,49 @@
 [
     {
-        sub      : "square",
-        input    : 1,
-        expected : 1,
-        name     : "test square 1"
+        "sub"      : "square",
+        "input"    : 1,
+        "expected" : 1,
+        "name"     : "test square 1"
     },
     {
-        sub      : "square",
-        input    : 2,
-        expected : 2,
-        name     : "test square 2"
+        "sub"      : "square",
+        "input"    : 2,
+        "expected" : 2,
+        "name"     : "test square 2"
     },
     {
-        sub      : "square",
-        input    : 3,
-        expected : 4,
-        name     : "test square 3"
+        "sub"      : "square",
+        "input"    : 3,
+        "expected" : 4,
+        "name"     : "test square 3"
     },
     {
-        sub      : "square",
-        input    : 4,
-        expected : 8,
-        name     : "test square 4"
+        "sub"      : "square",
+        "input"    : 4,
+        "expected" : 8,
+        "name"     : "test square 4"
     },
     {
-        sub      : "square",
-        input    : 16,
-        expected : 32768,
-        name     : "test square 16"
+        "sub"      : "square",
+        "input"    : 16,
+        "expected" : 32768,
+        "name"     : "test square 16"
     },
     {
-        sub      : "square",
-        input    : 32,
-        expected : 2147483648,
-        name     : "test square 32"
+        "sub"      : "square",
+        "input"    : 32,
+        "expected" : 2147483648,
+        "name"     : "test square 32"
     },
     {
-        sub      : "square",
-        input    : 64,
-        expected : 9223372036854775808,
-        name     : "test square 64"
+        "sub"      : "square",
+        "input"    : 64,
+        "expected" : 9223372036854775808,
+        "name"     : "test square 64"
     },
     {
-        sub      : "total",
-        expected : 18446744073709551615,
-        name     : "test total"
+        "sub"      : "total",
+        "expected" : 18446744073709551615,
+        "name"     : "test total"
     }
 ]

--- a/grains/grains.t
+++ b/grains/grains.t
@@ -9,7 +9,7 @@ my $cases;
 
 if (open my $fh, '<', $cases_file) {
     local $/ = undef;
-    $cases = from_json scalar <$fh>, { allow_barekey => 1 };
+    $cases = from_json scalar <$fh>;
 } else {
     die "Could not open '$cases_file' $!";
 }


### PR DESCRIPTION
Quoted keys in cases.json and removed allow_barekey from grains.t as it is not implemented in JSON::XS
