### PR TITLE
Test for truthiness instead of '0' or '1'

### DIFF
--- a/leap/leap.t
+++ b/leap/leap.t
@@ -3,16 +3,18 @@ use strict;
 use Test::More tests => 7;
 
 my $module = $ENV{EXERCISM} ? 'Example' : 'Leap';
-my $sub = $module . '::is_leap';
 
-use_ok($module) or BAIL_OUT ("You need to create a module called $module.pm.");
-can_ok($module, 'is_leap') or BAIL_OUT("Missing package $module with sub is_leap()");
+use_ok($module)
+    or BAIL_OUT ("You need to create a module called $module.pm.");
+can_ok($module, 'is_leap')
+    or BAIL_OUT("Missing package $module with sub is_leap()");
+
+my $sub = $module->can('is_leap');
 
 do {
-    no strict 'refs';
-    is $sub->(1996), 1, '1996 is a leap year';
-    is $sub->(1997), 0, '1997 is not a leap year';
-    is $sub->(1998), 0, '1998 is not a leap year';
-    is $sub->(1900), 0, '1900 is not a leap year';
-    is $sub->(2400), 1, '2400 is a leap year';
+    ok $sub->(1996), '1996 is a leap year';
+    ok !$sub->(1997), '1997 is not a leap year';
+    ok !$sub->(1998), '1998 is not a leap year';
+    ok !$sub->(1900), '1900 is not a leap year';
+    ok $sub->(2400), '2400 is a leap year';
 }


### PR DESCRIPTION
It's not usually appropriate to test a Perl predicate to see if it returns exactly `0` or `1`.  In particular, Perl's definitive false value is the empty string `''`, and functions that return the result of a boolean operation don't reliably return `0` unless they take pains to coerce the boolean into an int.  These tests check for the correct return values.
