### PR TITLE
Compare numbers numerically

### DIFF
--- a/grains/grains.t
+++ b/grains/grains.t
@@ -33,9 +33,9 @@ foreach my $c (@$cases) {
     my $sub = "${module}::" . $c->{sub};
 
     if ($c->{sub} eq 'square') {
-        is $sub->($c->{input}), $c->{expected}, $c->{name};
+        cmp_ok $sub->($c->{input}), '==', $c->{expected}, $c->{name};
     }
     if ($c->{sub} eq 'total') {
-        is $sub->(), $c->{expected}, $c->{name};
+        cmp_ok $sub->(), '==', $c->{expected}, $c->{name};
     }
 }


### PR DESCRIPTION
The old `grains.t` used `is` to test the values returned by the functions under test.  Unfortunately, `is` makes its comparisons with `eq` and the string representation of some of the numbers does not look as expected.  Using `cmp_ok` to perform numeric comparisons gets around this problem.
