### PR TITLE
Force internals to compare user submitted numbers with a bignum.

### DIFF
--- a/grains/grains.t
+++ b/grains/grains.t
@@ -2,14 +2,17 @@ use strict;
 use warnings;
 
 use Test::More;
-use JSON qw(from_json);
+use JSON::PP;
+use bigint;
 
 my $cases_file = 'cases.json';
 my $cases;
+my $decoder = JSON::PP->new();
+$decoder->allow_bignum(1);
 
 if (open my $fh, '<', $cases_file) {
     local $/ = undef;
-    $cases = from_json scalar <$fh>;
+    $cases = $decoder->decode( scalar <$fh> );
 } else {
     die "Could not open '$cases_file' $!";
 }
@@ -20,22 +23,19 @@ my $module = $ENV{EXERCISM} ? 'Example' : 'Grains';
 
 ok  -e "$module.pm", "Missing $module.pm" or BAIL_OUT "You need to create a class called $module.pm";
 
-eval "use $module";
-
-ok !$@, "Cannot load $module.pm"
+use_ok($module)
     or BAIL_OUT "Does $module.pm compile? Does it end with 1;?";
 
 can_ok $module, "square" or BAIL_OUT "Missing package $module; or missing sub square()";
 can_ok $module, "total"  or BAIL_OUT "Missing package $module; or missing sub total()";
 
 foreach my $c (@$cases) {
-    no strict 'refs';
-    my $sub = "${module}::" . $c->{sub};
+    my $sub = $module->can( $c->{sub} );
 
     if ($c->{sub} eq 'square') {
-        cmp_ok $sub->($c->{input}), '==', $c->{expected}, $c->{name};
+        cmp_ok $sub->($c->{input}), '==', 0 + $c->{expected}, $c->{name};
     }
     if ($c->{sub} eq 'total') {
-        cmp_ok $sub->(), '==', $c->{expected}, $c->{name};
+        cmp_ok $sub->(), '==', 0 + $c->{expected}, $c->{name};
     }
 }


### PR DESCRIPTION
Without this, users can happily simply return 2 *\* 64 from 'total'
 and have the test falsely "OK" it, because without bignum,

``` perl
 ( 2 ** 64 ) == ( ( 2 ** 64 ) - 1 )
```

Misc styleistic changes also.
