### PR TITLE
Use more "Modern" style skeleton in bob.pm

### DIFF
--- a/bob/bob.pm
+++ b/bob/bob.pm
@@ -3,18 +3,17 @@
 # first exercise more quickly.
 #
 
+use 5.006;
+use strict;
+use warnings;
+
 package Bob;
 
-use strict;
-use Exporter;
-use vars qw($VERSION @ISA @EXPORT @EXPORT_OK %EXPORT_TAGS);
+our $VERSION = '1.000';
 
-$VERSION = 1.00;
-@ISA = qw(Exporter);
-@EXPORT = ();
-@EXPORT_OK = qw(hey);
-%EXPORT_TAGS = ( DEFAULT => [qw(&hey)],
-);
+use Exporter 5.57 qw(import);
+
+our @EXPORT_OK = qw(hey);
 
 sub hey {
 #


### PR DESCRIPTION
As per exercism/exercism.io#2043 , The skeleton is incredibly outdated.

The use of Exporter is not even necessary to complete the bob exercise,
as the exercise calls functions directly, not importing them.

But Exporter related code is left in to continue to serve as an example
of how to do it for people who may attempt to re-use the style.

Strictures/Warnings standards and version declaration standards, as well
as variable declaration standards are all updated to the state of the
art since March 2000.

Also, unlike the previous example, this change avoids any kind of "default" exporting,
as best practices state exporting should be done on request, not by default,
except in special cases.

https://metacpan.org/pod/Perl::Critic::Policy::Modules::ProhibitAutomaticExportation#DESCRIPTION

This patch should closes exercism/exercism.io#2043
