### PR TITLE
Remove leading 'x' from repository name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# xPerl5
+# Exercism Perl 5 Track
 
-[![Gitter](https://badges.gitter.im/exercism/xperl.svg)](https://gitter.im/exercism/xperl?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+[![Gitter](https://badges.gitter.im/exercism/xperl5.svg)](https://gitter.im/exercism/xperl5?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
 Exercism exercises in Perl 5
 

--- a/config.json
+++ b/config.json
@@ -1,7 +1,7 @@
 {
   "slug": "perl5",
   "language": "Perl 5",
-  "repository": "https://github.com/exercism/xperl5",
+  "repository": "https://github.com/exercism/perl5",
   "active": true,
   "test_pattern": ".*\\.t$",
   "deprecated": [


### PR DESCRIPTION
The leading 'x' is kind of arbitrary. Especially now that we can set
topics on the repositories, we don't need a pattern to distinguish what
is a track or not.

The repository itself has already been renamed. GitHub redirects from
the old name to the new name, so we do not have to rush to fix links to
the old repository name, though we should update them for the sake of
clarity.

See exercism/meta#1