### PR TITLE
Use JSON formatted canonical-data

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ perl:
   - '5.18'
   - '5.16'
   - '5.14'
-  - '5.12'
 before_script:
   - git clone https://github.com/exercism/problem-specifications.git
   - bin/fetch-configlet

--- a/bin/cpanfile
+++ b/bin/cpanfile
@@ -1,5 +1,4 @@
 requires 'YAML';
 requires 'JSON::PP';
-requires 'Data::Dump';
 requires 'Path::Tiny';
 requires 'Template::Mustache';

--- a/bin/exercise-gen.pl
+++ b/bin/exercise-gen.pl
@@ -2,7 +2,6 @@
 use feature qw(lexical_subs say);
 use YAML 'LoadFile';
 use JSON::PP 'decode_json';
-use Data::Dump 'pp';
 use Path::Tiny qw(:DEFAULT cwd);
 use Template::Mustache 'render';
 
@@ -37,10 +36,7 @@ for my $exercise (@exercises) {
   my $data = LoadFile $yaml;
 
   my $cdata = $base_dir->child("problem-specifications/exercises/$exercise/canonical-data.json");
-  if ($cdata->is_file) {
-    $data->{cdata}{json} = $cdata->slurp;
-    $data->{cdata}{perl} = pp decode_json($data->{cdata}{json});
-  }
+  if ($cdata->is_file) {$data->{cdata}{json} = $cdata->slurp}
 
   my sub create_file {
     my ($filename, $template) = @_;

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -8,7 +8,7 @@
 
 ### Unix/Linux/Mac OSX:
 Perl is likely already installed. Run `perl -v` to check which version you have.
-If your version is older than v5.12.0, or you would like to try out newer versions
+If your version is older than v5.14.0, or you would like to try out newer versions
 of Perl 5, take a look at 'Other Options'.
 
 If you are using Fedora/Red Hat/CentOS, some core modules are not included with Perl.

--- a/exercises/bob/bob.t
+++ b/exercises/bob/bob.t
@@ -3,8 +3,8 @@ use strict;
 use warnings;
 use FindBin;
 my $dir;
-BEGIN { $dir = $FindBin::Bin . '/' };
-use lib $dir; # Look for the module inside the same directory as this test file.
+use lib $dir = $FindBin::Bin; # Look for the module inside the same directory as this test file.
+use JSON::PP;
 
 my $exercise = 'Bob'; # The name of this exercise.
 my $test_version = 2; # The version we will be matching against the exercise.
@@ -37,7 +37,6 @@ SKIP: {
   skip '', 1 unless $ENV{EXERCISM};
   is_deeply eval q{
     use Path::Tiny;
-    use JSON::PP 'decode_json';
     decode_json path("$dir/../../problem-specifications/exercises/".path($dir)->basename.'/canonical-data.json')->realpath->slurp;
   }, $C_DATA, 'canonical-data';
 }
@@ -46,159 +45,165 @@ done_testing; # There are no more tests after this :)
 
 # 'INIT' is a phaser, it makes sure that the test data is available before everything else
 # starts running (otherwise we'd have to shove the test data into the middle of the file!)
-INIT { $C_DATA = {
-  cases    => [
-                {
-                  description => "stating something",
-                  expected    => "Whatever.",
-                  input       => "Tom-ay-to, tom-aaaah-to.",
-                  property    => "response",
-                },
-                {
-                  description => "shouting",
-                  expected    => "Whoa, chill out!",
-                  input       => "WATCH OUT!",
-                  property    => "response",
-                },
-                {
-                  description => "shouting gibberish",
-                  expected    => "Whoa, chill out!",
-                  input       => "FCECDFCAAB",
-                  property    => "response",
-                },
-                {
-                  description => "asking a question",
-                  expected    => "Sure.",
-                  input       => "Does this cryogenic chamber make me look fat?",
-                  property    => "response",
-                },
-                {
-                  description => "asking a numeric question",
-                  expected    => "Sure.",
-                  input       => "You are, what, like 15?",
-                  property    => "response",
-                },
-                {
-                  description => "asking gibberish",
-                  expected    => "Sure.",
-                  input       => "fffbbcbeab?",
-                  property    => "response",
-                },
-                {
-                  description => "talking forcefully",
-                  expected    => "Whatever.",
-                  input       => "Let's go make out behind the gym!",
-                  property    => "response",
-                },
-                {
-                  description => "using acronyms in regular speech",
-                  expected    => "Whatever.",
-                  input       => "It's OK if you don't want to go to the DMV.",
-                  property    => "response",
-                },
-                {
-                  description => "forceful question",
-                  expected    => "Whoa, chill out!",
-                  input       => "WHAT THE HELL WERE YOU THINKING?",
-                  property    => "response",
-                },
-                {
-                  description => "shouting numbers",
-                  expected    => "Whoa, chill out!",
-                  input       => "1, 2, 3 GO!",
-                  property    => "response",
-                },
-                {
-                  description => "only numbers",
-                  expected    => "Whatever.",
-                  input       => "1, 2, 3",
-                  property    => "response",
-                },
-                {
-                  description => "question with only numbers",
-                  expected    => "Sure.",
-                  input       => "4?",
-                  property    => "response",
-                },
-                {
-                  description => "shouting with special characters",
-                  expected    => "Whoa, chill out!",
-                  input       => "ZOMG THE %^*\@#\$(*^ ZOMBIES ARE COMING!!11!!1!",
-                  property    => "response",
-                },
-                {
-                  description => "shouting with no exclamation mark",
-                  expected    => "Whoa, chill out!",
-                  input       => "I HATE YOU",
-                  property    => "response",
-                },
-                {
-                  description => "statement containing question mark",
-                  expected    => "Whatever.",
-                  input       => "Ending with ? means a question.",
-                  property    => "response",
-                },
-                {
-                  description => "non-letters with question",
-                  expected    => "Sure.",
-                  input       => ":) ?",
-                  property    => "response",
-                },
-                {
-                  description => "prattling on",
-                  expected    => "Sure.",
-                  input       => "Wait! Hang on. Are you going to be OK?",
-                  property    => "response",
-                },
-                {
-                  description => "silence",
-                  expected    => "Fine. Be that way!",
-                  input       => "",
-                  property    => "response",
-                },
-                {
-                  description => "prolonged silence",
-                  expected    => "Fine. Be that way!",
-                  input       => "          ",
-                  property    => "response",
-                },
-                {
-                  description => "alternate silence",
-                  expected    => "Fine. Be that way!",
-                  input       => "\t\t\t\t\t\t\t\t\t\t",
-                  property    => "response",
-                },
-                {
-                  description => "multiple line question",
-                  expected    => "Whatever.",
-                  input       => "\nDoes this cryogenic chamber make me look fat?\nno",
-                  property    => "response",
-                },
-                {
-                  description => "starting with whitespace",
-                  expected    => "Whatever.",
-                  input       => "         hmmmmmmm...",
-                  property    => "response",
-                },
-                {
-                  description => "ending with whitespace",
-                  expected    => "Sure.",
-                  input       => "Okay if like my  spacebar  quite a bit?   ",
-                  property    => "response",
-                },
-                {
-                  description => "other whitespace",
-                  expected    => "Fine. Be that way!",
-                  input       => "\n\r \t",
-                  property    => "response",
-                },
-                {
-                  description => "non-question ending with whitespace",
-                  expected    => "Whatever.",
-                  input       => "This is a statement ending with whitespace      ",
-                  property    => "response",
-                },
-              ],
-  exercise => "bob",
-  version  => "1.0.0",
-} }
+INIT {
+$C_DATA = decode_json <<'EOF';
+
+{
+  "exercise": "bob",
+  "version": "1.0.0",
+  "cases": [
+    {
+      "description": "stating something",
+      "property": "response",
+      "input": "Tom-ay-to, tom-aaaah-to.",
+      "expected": "Whatever."
+    },
+    {
+      "description": "shouting",
+      "property": "response",
+      "input": "WATCH OUT!",
+      "expected": "Whoa, chill out!"
+    },
+    {
+      "description": "shouting gibberish",
+      "property": "response",
+      "input": "FCECDFCAAB",
+      "expected": "Whoa, chill out!"
+    },
+    {
+      "description": "asking a question",
+      "property": "response",
+      "input": "Does this cryogenic chamber make me look fat?",
+      "expected": "Sure."
+    },
+    {
+      "description": "asking a numeric question",
+      "property": "response",
+      "input": "You are, what, like 15?",
+      "expected": "Sure."
+    },
+    {
+      "description": "asking gibberish",
+      "property": "response",
+      "input": "fffbbcbeab?",
+      "expected": "Sure."
+    },
+    {
+      "description": "talking forcefully",
+      "property": "response",
+      "input": "Let's go make out behind the gym!",
+      "expected": "Whatever."
+    },
+    {
+      "description": "using acronyms in regular speech",
+      "property": "response",
+      "input": "It's OK if you don't want to go to the DMV.",
+      "expected": "Whatever."
+    },
+    {
+      "description": "forceful question",
+      "property": "response",
+      "input": "WHAT THE HELL WERE YOU THINKING?",
+      "expected": "Whoa, chill out!"
+    },
+    {
+      "description": "shouting numbers",
+      "property": "response",
+      "input": "1, 2, 3 GO!",
+      "expected": "Whoa, chill out!"
+    },
+    {
+      "description": "only numbers",
+      "property": "response",
+      "input": "1, 2, 3",
+      "expected": "Whatever."
+    },
+    {
+      "description": "question with only numbers",
+      "property": "response",
+      "input": "4?",
+      "expected": "Sure."
+    },
+    {
+      "description": "shouting with special characters",
+      "property": "response",
+      "input": "ZOMG THE %^*@#$(*^ ZOMBIES ARE COMING!!11!!1!",
+      "expected": "Whoa, chill out!"
+    },
+    {
+      "description": "shouting with no exclamation mark",
+      "property": "response",
+      "input": "I HATE YOU",
+      "expected": "Whoa, chill out!"
+    },
+    {
+      "description": "statement containing question mark",
+      "property": "response",
+      "input": "Ending with ? means a question.",
+      "expected": "Whatever."
+    },
+    {
+      "description": "non-letters with question",
+      "property": "response",
+      "input": ":) ?",
+      "expected": "Sure."
+    },
+    {
+      "description": "prattling on",
+      "property": "response",
+      "input": "Wait! Hang on. Are you going to be OK?",
+      "expected": "Sure."
+    },
+    {
+      "description": "silence",
+      "property": "response",
+      "input": "",
+      "expected": "Fine. Be that way!"
+    },
+    {
+      "description": "prolonged silence",
+      "property": "response",
+      "input": "          ",
+      "expected": "Fine. Be that way!"
+    },
+    {
+      "description": "alternate silence",
+      "property": "response",
+      "input": "\t\t\t\t\t\t\t\t\t\t",
+      "expected": "Fine. Be that way!"
+    },
+    {
+      "description": "multiple line question",
+      "property": "response",
+      "input": "\nDoes this cryogenic chamber make me look fat?\nno",
+      "expected": "Whatever."
+    },
+    {
+      "description": "starting with whitespace",
+      "property": "response",
+      "input": "         hmmmmmmm...",
+      "expected": "Whatever."
+    },
+    {
+      "description": "ending with whitespace",
+      "property": "response",
+      "input": "Okay if like my  spacebar  quite a bit?   ",
+      "expected": "Sure."
+    },
+    {
+      "description": "other whitespace",
+      "property": "response",
+      "input": "\n\r \t",
+      "expected": "Fine. Be that way!"
+    },
+    {
+      "description": "non-question ending with whitespace",
+      "property": "response",
+      "input": "This is a statement ending with whitespace      ",
+      "expected": "Whatever."
+    }
+  ]
+}
+
+EOF
+}

--- a/exercises/hello-world/hello-world.t
+++ b/exercises/hello-world/hello-world.t
@@ -3,8 +3,8 @@ use strict;
 use warnings;
 use FindBin;
 my $dir;
-BEGIN { $dir = $FindBin::Bin . '/' };
-use lib $dir; # Look for the module inside the same directory as this test file.
+use lib $dir = $FindBin::Bin; # Look for the module inside the same directory as this test file.
+use JSON::PP;
 
 my $exercise = 'HelloWorld'; # The name of this exercise.
 my $test_version = 1; # The version we will be matching against the exercise.
@@ -37,7 +37,6 @@ SKIP: {
   skip '', 1 unless $ENV{EXERCISM};
   is_deeply eval q{
     use Path::Tiny;
-    use JSON::PP 'decode_json';
     decode_json path("$dir/../../problem-specifications/exercises/".path($dir)->basename.'/canonical-data.json')->realpath->slurp;
   }, $C_DATA, 'canonical-data';
 }
@@ -46,14 +45,20 @@ done_testing; # There are no more tests after this :)
 
 # 'INIT' is a phaser, it makes sure that the test data is available before everything else
 # starts running (otherwise we'd have to shove the test data into the middle of the file!)
-INIT { $C_DATA = {
-  cases    => [
-                {
-                  description => "Say Hi!",
-                  expected    => "Hello, World!",
-                  property    => "hello",
-                },
-              ],
-  exercise => "hello-world",
-  version  => "1.0.0",
-} }
+INIT {
+$C_DATA = decode_json <<'EOF';
+
+{
+  "exercise": "hello-world",
+  "version": "1.0.0",
+  "cases": [
+    {
+      "description": "Say Hi!",
+      "property": "hello",
+      "expected": "Hello, World!"
+    }
+  ]
+}
+
+EOF
+}

--- a/templates/test.mustache
+++ b/templates/test.mustache
@@ -1,10 +1,10 @@
 #!/usr/bin/env perl
 use strict;
 use warnings;
-use FindBin;
-my $dir;
-BEGIN { $dir = $FindBin::Bin . '/' };
-use lib $dir;{{#lib_comment}} {{&lib_comment}}{{/lib_comment}}{{#modules}}
+use FindBin;{{#cdata}}
+my $dir;{{/cdata}}
+use lib{{#cdata}} $dir ={{/cdata}} $FindBin::Bin;{{#lib_comment}} {{&lib_comment}}{{/lib_comment}}{{#cdata}}
+use JSON::PP;{{/cdata}}{{#modules}}
 use {{&use}};{{/modules}}
 
 my $exercise{{#exercise}} = '{{&exercise}}'{{/exercise}};{{#exercise_comment}} {{&exercise_comment}}{{/exercise_comment}}
@@ -39,7 +39,6 @@ SKIP: {
   skip '', 1 unless $ENV{EXERCISM};
   is_deeply eval q{
     use Path::Tiny;
-    use JSON::PP 'decode_json';
     decode_json path("$dir/../../problem-specifications/exercises/".path($dir)->basename.'/canonical-data.json')->realpath->slurp;
   }, $C_DATA, 'canonical-data';
 }
@@ -51,4 +50,9 @@ done_testing;{{#done_testing_comment}} {{&done_testing_comment}}{{/done_testing_
 {{#INIT_comment}}
 
 {{&INIT_comment}}{{/INIT_comment}}
-INIT { $C_DATA = {{&perl}} }{{/cdata}}
+INIT {
+$C_DATA = decode_json <<'EOF';
+
+{{&json}}
+EOF
+}{{/cdata}}


### PR DESCRIPTION
Unfortunately I had encountered some issues when using Data::Dump on canonical-data in some other exercises with the generator. JSON will likely be more reliable to work with.

JSON::PP is in core from 5.14 onwards, so I'm bumping the minimum up to 5.14.