### PR TITLE
Call configlet subcommand on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,5 @@ before_script:
   - git clone https://github.com/exercism/problem-specifications.git
   - bin/fetch-configlet
 script:
-  - bin/configlet .
+  - bin/configlet lint .
   - prove -r exercises/


### PR DESCRIPTION
This changes configlet to pass a subcommand.

For now, we've released a version of configlet which handles both the old command:

    configlet path/to/track

as well as the new command:

    configlet lint path/to/track

This will let us update all the travis files to include the subcommand before we
release the version of configlet that requires the subcommand.


https://github.com/exercism/configlet/pull/23