### PR TITLE
use Exporter for exporting subroutines from modules

### DIFF
--- a/exercises/bob/.meta/exercise-data.yaml
+++ b/exercises/bob/.meta/exercise-data.yaml
@@ -1,9 +1,9 @@
 exercise: Bob
-version: 3
-plan: 27
+version: 4
+plan: 26
 subs: hey
 tests: |-
-  is $subs{hey}->($_->{input}{heyBob}), $_->{expected}, $_->{description} foreach @{$C_DATA->{cases}};
+  is hey($_->{input}{heyBob}), $_->{expected}, $_->{description} foreach @{$C_DATA->{cases}};
 
 exercise_comment: '# The name of this exercise.'
 version_comment: '# The version we will be matching against the exercise.'

--- a/exercises/bob/.meta/solutions/Bob.pm
+++ b/exercises/bob/.meta/solutions/Bob.pm
@@ -1,7 +1,9 @@
 # Declare package 'Bob' with version
-package Bob 3;
+package Bob 4;
 use strict;
 use warnings;
+use Exporter 'import';
+our @EXPORT_OK = qw(hey);
 
 sub hey {
   my ($text) = @_;

--- a/exercises/bob/Bob.pm
+++ b/exercises/bob/Bob.pm
@@ -1,7 +1,9 @@
 # Declare package 'Bob' with version
-package Bob 3;
+package Bob 4;
 use strict;
 use warnings;
+use Exporter 'import';
+our @EXPORT_OK = qw(hey);
 
 sub hey {
   my ($msg) = @_;

--- a/exercises/bob/bob.t
+++ b/exercises/bob/bob.t
@@ -1,15 +1,14 @@
 #!/usr/bin/env perl
 use strict;
 use warnings;
+use JSON::PP;
 use FindBin;
 use lib $FindBin::Bin; # Look for the module inside the same directory as this test file.
-use JSON::PP;
+use Bob qw(hey);
 
 my $exercise = 'Bob'; # The name of this exercise.
-my $test_version = 3; # The version we will be matching against the exercise.
-use Test::More tests => 27; # This is how many tests we expect to run.
-
-use_ok $exercise or BAIL_OUT; # Check that the module can be use-d.
+my $test_version = 4; # The version we will be matching against the exercise.
+use Test::More tests => 26; # This is how many tests we expect to run.
 
 # If the exercise is updated, we want to make sure other people testing
 # your code don't think you've made a mistake if things have changed!
@@ -21,14 +20,10 @@ if ($exercise_version != $test_version) {
   BAIL_OUT if $ENV{EXERCISM};
 }
 
-my %subs;
-foreach ( qw(hey) ) {
-  can_ok $exercise, $_;
-  $subs{$_} = $exercise->can($_);
-}
+can_ok $exercise, 'import' or BAIL_OUT 'Cannot import subroutines from module';
 
 my $C_DATA = do { local $/; decode_json(<DATA>); };
-is $subs{hey}->($_->{input}{heyBob}), $_->{expected}, $_->{description} foreach @{$C_DATA->{cases}};
+is hey($_->{input}{heyBob}), $_->{expected}, $_->{description} foreach @{$C_DATA->{cases}};
 
 __DATA__
 {

--- a/exercises/clock/.meta/exercise-data.yaml
+++ b/exercises/clock/.meta/exercise-data.yaml
@@ -1,16 +1,16 @@
 exercise: Clock
-version: 1
-plan: 57
-subs: new time add_minutes subtract_minutes
+version: 2
+plan: 53
+methods: new time add_minutes subtract_minutes
 tests: |-
   foreach (@{$C_DATA->{cases}}) {
     foreach (@{$_->{cases}}) {
       if ($_->{property} eq 'create') {
-        is Clock->new($_->{input})->time, $_->{expected}, $_->{description};
+        is($exercise->new($_->{input})->time, $_->{expected}, $_->{description});
       }
 
       elsif ($_->{property} eq 'add' || $_->{property} eq 'subtract') {
-        my $clock = Clock->new({
+        my $clock = $exercise->new({
           hour   => $_->{input}{hour},
           minute => $_->{input}{minute},
         });
@@ -21,13 +21,13 @@ tests: |-
 
       elsif ($_->{property} eq 'equal') {
         ok $_->{expected} ==
-          (Clock->new($_->{input}{clock1})->time eq Clock->new($_->{input}{clock2})->time), $_->{description};
+          ($exercise->new($_->{input}{clock1})->time eq $exercise->new($_->{input}{clock2})->time), $_->{description};
       }
     }
   }
 
-  is Clock->new({hour => 0, minute => 0})->add_minutes(65)->time, '01:05', 'add_minutes method can be chained';
-  is Clock->new({hour => 0, minute => 0})->subtract_minutes(65)->time, '22:55', 'subtract_minutes method can be chained';
+  is($exercise->new({hour => 0, minute => 0})->add_minutes(65)->time, '01:05', 'add_minutes method can be chained');
+  is($exercise->new({hour => 0, minute => 0})->subtract_minutes(65)->time, '22:55', 'subtract_minutes method can be chained');
   
 stub: |-
   sub new {

--- a/exercises/clock/.meta/solutions/Clock.pm
+++ b/exercises/clock/.meta/solutions/Clock.pm
@@ -1,4 +1,4 @@
-package Clock 1;
+package Clock 2;
 use strict;
 use warnings;
 

--- a/exercises/clock/Clock.pm
+++ b/exercises/clock/Clock.pm
@@ -1,4 +1,4 @@
-package Clock 1;
+package Clock 2;
 use strict;
 use warnings;
 

--- a/exercises/clock/clock.t
+++ b/exercises/clock/clock.t
@@ -1,15 +1,14 @@
 #!/usr/bin/env perl
 use strict;
 use warnings;
+use JSON::PP;
 use FindBin;
 use lib $FindBin::Bin;
-use JSON::PP;
+use Clock ();
 
 my $exercise = 'Clock';
-my $test_version = 1;
-use Test::More tests => 57;
-
-use_ok $exercise or BAIL_OUT;
+my $test_version = 2;
+use Test::More tests => 53;
 
 my $exercise_version = $exercise->VERSION // 0;
 if ($exercise_version != $test_version) {
@@ -19,21 +18,17 @@ if ($exercise_version != $test_version) {
   BAIL_OUT if $ENV{EXERCISM};
 }
 
-my %subs;
-foreach ( qw(new time add_minutes subtract_minutes) ) {
-  can_ok $exercise, $_;
-  $subs{$_} = $exercise->can($_);
-}
+can_ok $exercise, qw(new time add_minutes subtract_minutes);
 
 my $C_DATA = do { local $/; decode_json(<DATA>); };
 foreach (@{$C_DATA->{cases}}) {
   foreach (@{$_->{cases}}) {
     if ($_->{property} eq 'create') {
-      is Clock->new($_->{input})->time, $_->{expected}, $_->{description};
+      is($exercise->new($_->{input})->time, $_->{expected}, $_->{description});
     }
 
     elsif ($_->{property} eq 'add' || $_->{property} eq 'subtract') {
-      my $clock = Clock->new({
+      my $clock = $exercise->new({
         hour   => $_->{input}{hour},
         minute => $_->{input}{minute},
       });
@@ -44,13 +39,13 @@ foreach (@{$C_DATA->{cases}}) {
 
     elsif ($_->{property} eq 'equal') {
       ok $_->{expected} ==
-        (Clock->new($_->{input}{clock1})->time eq Clock->new($_->{input}{clock2})->time), $_->{description};
+        ($exercise->new($_->{input}{clock1})->time eq $exercise->new($_->{input}{clock2})->time), $_->{description};
     }
   }
 }
 
-is Clock->new({hour => 0, minute => 0})->add_minutes(65)->time, '01:05', 'add_minutes method can be chained';
-is Clock->new({hour => 0, minute => 0})->subtract_minutes(65)->time, '22:55', 'subtract_minutes method can be chained';
+is($exercise->new({hour => 0, minute => 0})->add_minutes(65)->time, '01:05', 'add_minutes method can be chained');
+is($exercise->new({hour => 0, minute => 0})->subtract_minutes(65)->time, '22:55', 'subtract_minutes method can be chained');
 
 __DATA__
 {

--- a/exercises/hello-world/.meta/exercise-data.yaml
+++ b/exercises/hello-world/.meta/exercise-data.yaml
@@ -1,9 +1,9 @@
 exercise: HelloWorld
-version: 1
-plan: 3
+version: 2
+plan: 2
 subs: hello
 tests: |-
-  is $subs{hello}->($_->{input}), $_->{expected}, $_->{description} foreach @{$C_DATA->{cases}};
+  is hello($_->{input}), $_->{expected}, $_->{description} foreach @{$C_DATA->{cases}};
 
 exercise_comment: '# The name of this exercise.'
 version_comment: '# The version we will be matching against the exercise.'

--- a/exercises/hello-world/.meta/solutions/HelloWorld.pm
+++ b/exercises/hello-world/.meta/solutions/HelloWorld.pm
@@ -1,7 +1,9 @@
 # Declare package 'HelloWorld' with version
-package HelloWorld 1;
+package HelloWorld 2;
 use strict;
 use warnings;
+use Exporter 'import';
+our @EXPORT_OK = qw(hello);
 
 sub hello {
   return 'Hello, World!';

--- a/exercises/hello-world/HelloWorld.pm
+++ b/exercises/hello-world/HelloWorld.pm
@@ -1,7 +1,9 @@
 # Declare package 'HelloWorld' with version
-package HelloWorld 1;
+package HelloWorld 2;
 use strict;
 use warnings;
+use Exporter 'import';
+our @EXPORT_OK = qw(hello);
 
 sub hello {
   # Remove the comments and write some code here to pass the test suite.

--- a/exercises/hello-world/hello-world.t
+++ b/exercises/hello-world/hello-world.t
@@ -1,15 +1,14 @@
 #!/usr/bin/env perl
 use strict;
 use warnings;
+use JSON::PP;
 use FindBin;
 use lib $FindBin::Bin; # Look for the module inside the same directory as this test file.
-use JSON::PP;
+use HelloWorld qw(hello);
 
 my $exercise = 'HelloWorld'; # The name of this exercise.
-my $test_version = 1; # The version we will be matching against the exercise.
-use Test::More tests => 3; # This is how many tests we expect to run.
-
-use_ok $exercise or BAIL_OUT; # Check that the module can be use-d.
+my $test_version = 2; # The version we will be matching against the exercise.
+use Test::More tests => 2; # This is how many tests we expect to run.
 
 # If the exercise is updated, we want to make sure other people testing
 # your code don't think you've made a mistake if things have changed!
@@ -21,14 +20,10 @@ if ($exercise_version != $test_version) {
   BAIL_OUT if $ENV{EXERCISM};
 }
 
-my %subs;
-foreach ( qw(hello) ) {
-  can_ok $exercise, $_;
-  $subs{$_} = $exercise->can($_);
-}
+can_ok $exercise, 'import' or BAIL_OUT 'Cannot import subroutines from module';
 
 my $C_DATA = do { local $/; decode_json(<DATA>); };
-is $subs{hello}->($_->{input}), $_->{expected}, $_->{description} foreach @{$C_DATA->{cases}};
+is hello($_->{input}), $_->{expected}, $_->{description} foreach @{$C_DATA->{cases}};
 
 __DATA__
 {

--- a/exercises/leap/.meta/exercise-data.yaml
+++ b/exercises/leap/.meta/exercise-data.yaml
@@ -1,9 +1,9 @@
 exercise: Leap
-version: 2
-plan: 6
+version: 3
+plan: 5
 subs: is_leap
 tests: |-
-  is $subs{is_leap}->($_->{input}{year}), $_->{expected}, $_->{description} foreach @{$C_DATA->{cases}};
+  is is_leap($_->{input}{year}), $_->{expected}, $_->{description} foreach @{$C_DATA->{cases}};
 
 exercise_comment: '# The name of this exercise.'
 version_comment: '# The version we will be matching against the exercise.'

--- a/exercises/leap/.meta/solutions/Leap.pm
+++ b/exercises/leap/.meta/solutions/Leap.pm
@@ -1,7 +1,9 @@
 # Declare package 'Leap' with version
-package Leap 2;
+package Leap 3;
 use strict;
 use warnings;
+use Exporter 'import';
+our @EXPORT_OK = qw(is_leap);
 
 sub is_leap {
   my $year = shift;

--- a/exercises/leap/Leap.pm
+++ b/exercises/leap/Leap.pm
@@ -1,7 +1,9 @@
 # Declare package 'Leap' with version
-package Leap 2;
+package Leap 3;
 use strict;
 use warnings;
+use Exporter 'import';
+our @EXPORT_OK = qw(is_leap);
 
 sub is_leap {
   my ($year) = @_;

--- a/exercises/leap/leap.t
+++ b/exercises/leap/leap.t
@@ -1,15 +1,14 @@
 #!/usr/bin/env perl
 use strict;
 use warnings;
+use JSON::PP;
 use FindBin;
 use lib $FindBin::Bin; # Look for the module inside the same directory as this test file.
-use JSON::PP;
+use Leap qw(is_leap);
 
 my $exercise = 'Leap'; # The name of this exercise.
-my $test_version = 2; # The version we will be matching against the exercise.
-use Test::More tests => 6; # This is how many tests we expect to run.
-
-use_ok $exercise or BAIL_OUT; # Check that the module can be use-d.
+my $test_version = 3; # The version we will be matching against the exercise.
+use Test::More tests => 5; # This is how many tests we expect to run.
 
 # If the exercise is updated, we want to make sure other people testing
 # your code don't think you've made a mistake if things have changed!
@@ -21,14 +20,10 @@ if ($exercise_version != $test_version) {
   BAIL_OUT if $ENV{EXERCISM};
 }
 
-my %subs;
-foreach ( qw(is_leap) ) {
-  can_ok $exercise, $_;
-  $subs{$_} = $exercise->can($_);
-}
+can_ok $exercise, 'import' or BAIL_OUT 'Cannot import subroutines from module';
 
 my $C_DATA = do { local $/; decode_json(<DATA>); };
-is $subs{is_leap}->($_->{input}{year}), $_->{expected}, $_->{description} foreach @{$C_DATA->{cases}};
+is is_leap($_->{input}{year}), $_->{expected}, $_->{description} foreach @{$C_DATA->{cases}};
 
 __DATA__
 {

--- a/exercises/luhn/.meta/exercise-data.yaml
+++ b/exercises/luhn/.meta/exercise-data.yaml
@@ -1,9 +1,9 @@
 exercise: Luhn
-version: 2
-plan: 15
+version: 3
+plan: 14
 subs: is_luhn_valid
 tests: |-
-  is $subs{is_luhn_valid}->($_->{input}{value}), $_->{expected}, $_->{description} foreach @{$C_DATA->{cases}};
+  is is_luhn_valid($_->{input}{value}), $_->{expected}, $_->{description} foreach @{$C_DATA->{cases}};
 
 example: |-
   sub is_luhn_valid {

--- a/exercises/luhn/.meta/solutions/Luhn.pm
+++ b/exercises/luhn/.meta/solutions/Luhn.pm
@@ -1,6 +1,8 @@
-package Luhn 2;
+package Luhn 3;
 use strict;
 use warnings;
+use Exporter 'import';
+our @EXPORT_OK = qw(is_luhn_valid);
 
 sub is_luhn_valid {
   my ($input) = @_;

--- a/exercises/luhn/Luhn.pm
+++ b/exercises/luhn/Luhn.pm
@@ -1,6 +1,8 @@
-package Luhn 2;
+package Luhn 3;
 use strict;
 use warnings;
+use Exporter 'import';
+our @EXPORT_OK = qw(is_luhn_valid);
 
 sub is_luhn_valid {
   my ($input) = @_;

--- a/exercises/luhn/luhn.t
+++ b/exercises/luhn/luhn.t
@@ -1,15 +1,14 @@
 #!/usr/bin/env perl
 use strict;
 use warnings;
+use JSON::PP;
 use FindBin;
 use lib $FindBin::Bin;
-use JSON::PP;
+use Luhn qw(is_luhn_valid);
 
 my $exercise = 'Luhn';
-my $test_version = 2;
-use Test::More tests => 15;
-
-use_ok $exercise or BAIL_OUT;
+my $test_version = 3;
+use Test::More tests => 14;
 
 my $exercise_version = $exercise->VERSION // 0;
 if ($exercise_version != $test_version) {
@@ -19,14 +18,10 @@ if ($exercise_version != $test_version) {
   BAIL_OUT if $ENV{EXERCISM};
 }
 
-my %subs;
-foreach ( qw(is_luhn_valid) ) {
-  can_ok $exercise, $_;
-  $subs{$_} = $exercise->can($_);
-}
+can_ok $exercise, 'import' or BAIL_OUT 'Cannot import subroutines from module';
 
 my $C_DATA = do { local $/; decode_json(<DATA>); };
-is $subs{is_luhn_valid}->($_->{input}{value}), $_->{expected}, $_->{description} foreach @{$C_DATA->{cases}};
+is is_luhn_valid($_->{input}{value}), $_->{expected}, $_->{description} foreach @{$C_DATA->{cases}};
 
 __DATA__
 {

--- a/exercises/phone-number/.meta/exercise-data.yaml
+++ b/exercises/phone-number/.meta/exercise-data.yaml
@@ -1,10 +1,10 @@
 exercise: PhoneNumber
-version: 3
-plan: 16
+version: 4
+plan: 15
 subs: clean_number
 tests: |-
   foreach my $subcases (@{$C_DATA->{cases}}) {
-    is $subs{clean_number}->($_->{input}{phrase}), $_->{expected}, $_->{description} foreach @{$subcases->{cases}};
+    is clean_number($_->{input}{phrase}), $_->{expected}, $_->{description} foreach @{$subcases->{cases}};
   }
 
 example: |

--- a/exercises/phone-number/.meta/solutions/PhoneNumber.pm
+++ b/exercises/phone-number/.meta/solutions/PhoneNumber.pm
@@ -1,6 +1,8 @@
-package PhoneNumber 3;
+package PhoneNumber 4;
 use strict;
 use warnings;
+use Exporter 'import';
+our @EXPORT_OK = qw(clean_number);
 
 sub clean_number {
   my ($number) = @_;

--- a/exercises/phone-number/PhoneNumber.pm
+++ b/exercises/phone-number/PhoneNumber.pm
@@ -1,5 +1,7 @@
-package PhoneNumber 3;
+package PhoneNumber 4;
 use strict;
 use warnings;
+use Exporter 'import';
+our @EXPORT_OK = qw(clean_number);
 
 1;

--- a/exercises/phone-number/phone-number.t
+++ b/exercises/phone-number/phone-number.t
@@ -1,15 +1,14 @@
 #!/usr/bin/env perl
 use strict;
 use warnings;
+use JSON::PP;
 use FindBin;
 use lib $FindBin::Bin;
-use JSON::PP;
+use PhoneNumber qw(clean_number);
 
 my $exercise = 'PhoneNumber';
-my $test_version = 3;
-use Test::More tests => 16;
-
-use_ok $exercise or BAIL_OUT;
+my $test_version = 4;
+use Test::More tests => 15;
 
 my $exercise_version = $exercise->VERSION // 0;
 if ($exercise_version != $test_version) {
@@ -19,15 +18,11 @@ if ($exercise_version != $test_version) {
   BAIL_OUT if $ENV{EXERCISM};
 }
 
-my %subs;
-foreach ( qw(clean_number) ) {
-  can_ok $exercise, $_;
-  $subs{$_} = $exercise->can($_);
-}
+can_ok $exercise, 'import' or BAIL_OUT 'Cannot import subroutines from module';
 
 my $C_DATA = do { local $/; decode_json(<DATA>); };
 foreach my $subcases (@{$C_DATA->{cases}}) {
-  is $subs{clean_number}->($_->{input}{phrase}), $_->{expected}, $_->{description} foreach @{$subcases->{cases}};
+  is clean_number($_->{input}{phrase}), $_->{expected}, $_->{description} foreach @{$subcases->{cases}};
 }
 
 __DATA__

--- a/templates/module.mustache
+++ b/templates/module.mustache
@@ -1,7 +1,9 @@
 {{#package_comment}}{{&package_comment}}
 {{/package_comment}}package {{&exercise}} {{&version}};
 use strict;
-use warnings;{{#module_file}}
+use warnings;{{#subs}}
+use Exporter 'import';
+our @EXPORT_OK = qw({{&subs}});{{/subs}}{{#module_file}}
 
 {{&module_file}}{{/module_file}}
 

--- a/templates/test.mustache
+++ b/templates/test.mustache
@@ -1,16 +1,15 @@
 #!/usr/bin/env perl
 use strict;
-use warnings;
+use warnings;{{#cdata}}
+use JSON::PP;{{/cdata}}
 use FindBin;
-use lib $FindBin::Bin;{{#lib_comment}} {{&lib_comment}}{{/lib_comment}}{{#cdata}}
-use JSON::PP;{{/cdata}}{{#modules}}
+use lib $FindBin::Bin;{{#lib_comment}} {{&lib_comment}}{{/lib_comment}}
+use {{&exercise}} {{#subs}}qw{{/subs}}({{&subs}});{{#modules}}
 use {{&use}};{{/modules}}
 
 my $exercise{{#exercise}} = '{{&exercise}}'{{/exercise}};{{#exercise_comment}} {{&exercise_comment}}{{/exercise_comment}}
 my $test_version{{#version}} = {{&version}}{{/version}};{{#version_comment}} {{&version_comment}}{{/version_comment}}
 use Test::More{{#plan}} tests => {{&plan}}{{/plan}};{{#plan_comment}} {{&plan_comment}}{{/plan_comment}}
-
-use_ok $exercise or BAIL_OUT;{{#use_test_comment}} {{&use_test_comment}}{{/use_test_comment}}
 {{#version_test_comment}}
 {{&version_test_comment}}{{/version_test_comment}}
 my $exercise_version = $exercise->VERSION // 0;
@@ -22,12 +21,9 @@ if ($exercise_version != $test_version) {
 }
 {{#subs}}
 
-my %subs;
-foreach ( qw({{&subs}}) ) {
-  can_ok $exercise, $_;
-  $subs{$_} = $exercise->can($_);
-}
-{{/subs}}{{#cdata}}
+can_ok $exercise, 'import' or BAIL_OUT 'Cannot import subroutines from module';{{/subs}}{{#methods}}
+can_ok $exercise, qw({{&methods}});{{/methods}}{{#cdata}}
+
 my $C_DATA = do { local $/; decode_json(<DATA>); };{{/cdata}}
 {{&tests}}
 {{#cdata}}


### PR DESCRIPTION
Now that we no longer have modules named `Example`, we can `use` modules directly and import their subroutines in a standard fashion.