### PR TITLE
Improve truth/falsehood test for Leap

### DIFF
--- a/exercises/leap/.meta/exercise-data.yaml
+++ b/exercises/leap/.meta/exercise-data.yaml
@@ -1,9 +1,9 @@
 exercise: Leap
-version: 3
+version: 4
 plan: 5
 subs: is_leap
 tests: |-
-  is is_leap($_->{input}{year}), $_->{expected}, $_->{description} foreach @{$C_DATA->{cases}};
+  ok !(is_leap($_->{input}{year}) xor $_->{expected}), $_->{description} foreach @{$C_DATA->{cases}};
 
 exercise_comment: '# The name of this exercise.'
 version_comment: '# The version we will be matching against the exercise.'
@@ -17,9 +17,7 @@ version_test_comment: |-
 example: |-
   sub is_leap {
     my $year = shift;
-    divisible_by($year, 400)
-      or divisible_by($year, 4) and !divisible_by($year, 100)
-      ? 1 : 0;
+    divisible_by($year, 400) or divisible_by($year, 4) and !divisible_by($year, 100);
   }
 
   sub divisible_by {

--- a/exercises/leap/.meta/solutions/Leap.pm
+++ b/exercises/leap/.meta/solutions/Leap.pm
@@ -1,5 +1,5 @@
 # Declare package 'Leap' with version
-package Leap 3;
+package Leap 4;
 use strict;
 use warnings;
 use Exporter 'import';
@@ -7,9 +7,7 @@ our @EXPORT_OK = qw(is_leap);
 
 sub is_leap {
   my $year = shift;
-  divisible_by($year, 400)
-    or divisible_by($year, 4) and !divisible_by($year, 100)
-    ? 1 : 0;
+  divisible_by($year, 400) or divisible_by($year, 4) and !divisible_by($year, 100);
 }
 
 sub divisible_by {

--- a/exercises/leap/Leap.pm
+++ b/exercises/leap/Leap.pm
@@ -1,5 +1,5 @@
 # Declare package 'Leap' with version
-package Leap 3;
+package Leap 4;
 use strict;
 use warnings;
 use Exporter 'import';

--- a/exercises/leap/leap.t
+++ b/exercises/leap/leap.t
@@ -7,7 +7,7 @@ use lib $FindBin::Bin; # Look for the module inside the same directory as this t
 use Leap qw(is_leap);
 
 my $exercise = 'Leap'; # The name of this exercise.
-my $test_version = 3; # The version we will be matching against the exercise.
+my $test_version = 4; # The version we will be matching against the exercise.
 use Test::More tests => 5; # This is how many tests we expect to run.
 
 # If the exercise is updated, we want to make sure other people testing
@@ -23,7 +23,7 @@ if ($exercise_version != $test_version) {
 can_ok $exercise, 'import' or BAIL_OUT 'Cannot import subroutines from module';
 
 my $C_DATA = do { local $/; decode_json(<DATA>); };
-is is_leap($_->{input}{year}), $_->{expected}, $_->{description} foreach @{$C_DATA->{cases}};
+ok !(is_leap($_->{input}{year}) xor $_->{expected}), $_->{description} foreach @{$C_DATA->{cases}};
 
 __DATA__
 {


### PR DESCRIPTION
The previous test was doing a string comparison on whether the returned value was either `1` or `0`. With this change, it should be possible to pass the test by returning any value which would be considered either true or false (Perl 5 does not have a boolean type).