### PR TITLE
Add argument set to generator script

### DIFF
--- a/bin/exercise-gen.pl
+++ b/bin/exercise-gen.pl
@@ -11,10 +11,11 @@ my $base_dir = path(__FILE__)->realpath->parent->parent;
 my @exercises;
 
 if (@ARGV) {
-  if ($ARGV[0] eq '--all') {
+  my %arg_set = map {$_ => 1} @ARGV;
+  if ($arg_set{'--all'}) {
     push @exercises, $_->basename foreach $base_dir->child('exercises')->children;
   } else {
-    @exercises = @ARGV;
+    @exercises = keys %arg_set;
   }
 } else {
   say 'No args given; working in current directory.';


### PR DESCRIPTION
This allows the `--all` argument to be in any position, and prevents exercises from accidentally being generated multiple times.