### PR TITLE
Replace `is` with `cmp_ok` for numeric comparison in grains

### DIFF
--- a/exercises/grains/.meta/exercise-data.yaml
+++ b/exercises/grains/.meta/exercise-data.yaml
@@ -12,13 +12,13 @@ tests: |-
             push @exception_cases, $case;
           }
           else {
-            is grains_on_square($case->{input}{square}), $case->{expected}, 'square no. ' . $case->{description};
+            cmp_ok grains_on_square($case->{input}{square}), '==', $case->{expected}, 'square no. ' . $case->{description};
           }
         }
       }
     }
     elsif ($_->{property} eq 'total') {
-      is total_grains(), $_->{expected}, $_->{description};
+      cmp_ok total_grains(), '==', $_->{expected}, $_->{description};
     }
   }
 
@@ -27,7 +27,7 @@ tests: |-
     skip 'Test::Fatal not loaded', scalar @exception_cases if $@;
     eval q{
       use Test::Fatal qw(dies_ok);
-      dies_ok {grains_on_square($_->{input}{square})} $_->{description} foreach @exception_cases;
+      dies_ok {grains_on_square $_->{input}{square}} $_->{description} foreach @exception_cases;
     };
   }
 
@@ -37,7 +37,7 @@ example: |-
     if ($square < 1 || $square > 64) {
       die 'invalid square';
     }
-    return int 2 ** ($square - 1);
+    return 2 ** ($square - 1);
   }
 
   sub total_grains {
@@ -48,7 +48,10 @@ example: |-
 
 stub: |-
   sub grains_on_square {
+    my ($square) = @_;
+    return undef;
   }
 
   sub total_grains {
+    return undef;
   }

--- a/exercises/grains/.meta/solutions/Grains.pm
+++ b/exercises/grains/.meta/solutions/Grains.pm
@@ -9,7 +9,7 @@ sub grains_on_square {
   if ($square < 1 || $square > 64) {
     die 'invalid square';
   }
-  return int 2 ** ($square - 1);
+  return 2 ** ($square - 1);
 }
 
 sub total_grains {

--- a/exercises/grains/Grains.pm
+++ b/exercises/grains/Grains.pm
@@ -5,9 +5,12 @@ use Exporter 'import';
 our @EXPORT_OK = qw(grains_on_square total_grains);
 
 sub grains_on_square {
+  my ($square) = @_;
+  return undef;
 }
 
 sub total_grains {
+  return undef;
 }
 
 1;

--- a/exercises/grains/grains.t
+++ b/exercises/grains/grains.t
@@ -20,13 +20,13 @@ foreach (@{$C_DATA->{cases}}) {
           push @exception_cases, $case;
         }
         else {
-          is grains_on_square($case->{input}{square}), $case->{expected}, 'square no. ' . $case->{description};
+          cmp_ok grains_on_square($case->{input}{square}), '==', $case->{expected}, 'square no. ' . $case->{description};
         }
       }
     }
   }
   elsif ($_->{property} eq 'total') {
-    is total_grains(), $_->{expected}, $_->{description};
+    cmp_ok total_grains(), '==', $_->{expected}, $_->{description};
   }
 }
 
@@ -35,7 +35,7 @@ SKIP: {
   skip 'Test::Fatal not loaded', scalar @exception_cases if $@;
   eval q{
     use Test::Fatal qw(dies_ok);
-    dies_ok {grains_on_square($_->{input}{square})} $_->{description} foreach @exception_cases;
+    dies_ok {grains_on_square $_->{input}{square}} $_->{description} foreach @exception_cases;
   };
 }
 


### PR DESCRIPTION
`is` is for string comparison and is not reliable for large numbers.