### PR TITLE
Run tests with both prove and yath

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ perl:
   - '5.16'
   - '5.14'
 install:
-  - curl -sL --compressed https://git.io/cpm | perl - install -g App::cpm
-  - cpm install
+  - wget -P ~/bin https://git.io/cpm
+  - chmod +x ~/bin/cpm
   - for i in exercises/*/.meta/solutions; do cd $i; if [ -f cpanfile ]; then echo "$i"; cpm install; fi; cd - > /dev/null; done
 before_script:
   - git clone https://github.com/exercism/problem-specifications.git
@@ -22,5 +22,7 @@ script:
     --recurse
     --directives
     --jobs 2
-  - prove -I local/lib/perl5
-    --directives
+  - cpm install
+  - perl -Ilocal/lib/perl5 local/bin/yath test exercises/*/.meta/solutions/
+  - TS_MAX_DELTA=3 perl -Ilocal/lib/perl5 local/bin/yath test t/
+    --verbose

--- a/cpanfile
+++ b/cpanfile
@@ -1,3 +1,5 @@
-requires 'YAML';
+requires 'App::Yath';
 requires 'Path::Tiny';
 requires 'Template::Mustache';
+requires 'Test2::V0';
+requires 'YAML';

--- a/t/generated-tests.t
+++ b/t/generated-tests.t
@@ -1,7 +1,5 @@
 #!/usr/bin/env perl
-use strict;
-use warnings;
-use Test::More;
+use Test2::V0;
 use Path::Tiny;
 use YAML 'LoadFile';
 use FindBin;
@@ -9,16 +7,22 @@ use lib "$FindBin::Bin/../lib";
 use Exercism::Generator 'BASE_DIR';
 
 if (!BASE_DIR->child('problem-specifications')->is_dir) {
-  BAIL_OUT 'problem-specifications directory required';
+  bail_out 'problem-specifications directory required';
 }
 
 foreach (sort {$a cmp $b} BASE_DIR->child('exercises')->children) {
   if ($_->child('.meta/exercise-data.yaml')->is_file) {
-    TODO: {
-      local $TODO = '#';
-      is $_->child($_->basename.'.t')->slurp,
-        Exercism::Generator->new({data => LoadFile($_->child('.meta/exercise-data.yaml')), exercise => $_->basename})->test,
-        $_->basename.': test suite matches generated';
+    todo '' => sub {
+      is(
+        [split(/\n/, $_->child($_->basename.'.t')->slurp)],
+        [split(/\n/, Exercism::Generator->new(
+          {
+            data => LoadFile($_->child('.meta/exercise-data.yaml')),
+            exercise => $_->basename,
+          }
+        )->test)],
+        $_->basename.': test suite matches generated'
+      );
     }
   }
 }


### PR DESCRIPTION
Yath (Yet Another Test Harness) [can be thought of as a more powerful alternative to prove](https://metacpan.org/pod/App::Yath). Adding it to travis to ensure that there are no issues running the exercise tests with either yath or prove.