### PR TITLE
Add ignore-side-comment-lengths to perltidy

### DIFF
--- a/.perltidyrc
+++ b/.perltidyrc
@@ -3,3 +3,4 @@
 --indent-columns=2
 --continuation-indentation=2
 --maximum-line-length=70
+--ignore-side-comment-lengths

--- a/exercises/bob/bob.t
+++ b/exercises/bob/bob.t
@@ -6,8 +6,7 @@ plan 26;    # This is how many tests we expect to run.
 
 use JSON::PP;
 use FindBin qw($Bin);
-use lib $Bin, "$Bin/local/lib/perl5"
-  ;         # Look for modules inside the same dir as this file.
+use lib $Bin, "$Bin/local/lib/perl5"; # Look for modules inside the same dir as this file.
 use Bob qw(hey);
 
 can_ok 'Bob', 'import'

--- a/exercises/hello-world/hello-world.t
+++ b/exercises/hello-world/hello-world.t
@@ -3,8 +3,7 @@ use Test2::V0;
 plan 2;    # This is how many tests we expect to run.
 
 use FindBin qw($Bin);
-use lib $Bin,
-  "$Bin/local/lib/perl5"; # Find modules in the same dir as this file.
+use lib $Bin, "$Bin/local/lib/perl5"; # Find modules in the same dir as this file.
 use HelloWorld qw(hello);
 
 imported_ok qw(hello) or bail_out;

--- a/exercises/leap/leap.t
+++ b/exercises/leap/leap.t
@@ -6,8 +6,7 @@ plan 6;    # This is how many tests we expect to run.
 
 use JSON::PP;
 use FindBin qw($Bin);
-use lib $Bin,
-  "$Bin/local/lib/perl5"; # Find modules in the same dir as this file.
+use lib $Bin, "$Bin/local/lib/perl5"; # Find modules in the same dir as this file.
 use Leap qw(is_leap_year);
 
 can_ok 'Leap', 'import'


### PR DESCRIPTION
A small change to prevent wrapping of lines with trailing comments. Seems unnecessary to do so in my opinion.