### PR TITLE
Add cpanfile with recommends/suggests for OO modules

### DIFF
--- a/exercises/clock/cpanfile
+++ b/exercises/clock/cpanfile
@@ -1,0 +1,4 @@
+recommends 'Moo';       # https://perldoc.pl/Moo
+suggests 'Mo';          # https://perldoc.pl/Mo
+suggests 'Moose';       # https://perldoc.pl/Moose
+suggests 'Class::Tiny'; # https://perldoc.pl/Class::Tiny


### PR DESCRIPTION
Can be installed via the command line with a simple `cpm install --with-{recommends,suggests}`

I considered opting for one of the simpler OOP modules, but ended up going with Moo as the recommended due to its ubiquity and available resources.