### PR TITLE
Use non-utf8 JSON object for test data

### DIFF
--- a/templates/test.mustache
+++ b/templates/test.mustache
@@ -8,7 +8,8 @@ use lib $Bin, "$Bin/local/lib/perl5";{{#lib_comment}} {{&lib_comment}}{{/lib_com
 use {{&exercise}} {{#subs}}qw{{/subs}}({{&subs}});{{#modules}}
 use {{&use}};{{/modules}}
 {{#cdata}}
-my $C_DATA = do { local $/; decode_json(<DATA>); };{{/cdata}}{{#plan}}
+my $json = JSON::PP->new;
+my $C_DATA = do { local $/; $json->decode(<DATA>); };{{/cdata}}{{#plan}}
 plan {{&plan}};{{#plan_comment}} {{&plan_comment}}{{/plan_comment}}{{/plan}}
 {{#subs}}
 imported_ok qw({{&subs}}) or bail_out;{{/subs}}{{#methods}}

--- a/templates/test.mustache
+++ b/templates/test.mustache
@@ -1,6 +1,7 @@
 #!/usr/bin/env perl
 use Test2::V0;{{#cdata}}
-use JSON::PP;{{/cdata}}
+use JSON::PP;
+use constant JSON => JSON::PP->new;{{/cdata}}
 
 use FindBin qw($Bin);
 use lib $Bin, "$Bin/local/lib/perl5";{{#lib_comment}} {{&lib_comment}}{{/lib_comment}}
@@ -8,8 +9,7 @@ use lib $Bin, "$Bin/local/lib/perl5";{{#lib_comment}} {{&lib_comment}}{{/lib_com
 use {{&exercise}} {{#subs}}qw{{/subs}}({{&subs}});{{#modules}}
 use {{&use}};{{/modules}}
 {{#cdata}}
-my $json = JSON::PP->new;
-my $C_DATA = do { local $/; $json->decode(<DATA>); };{{/cdata}}{{#plan}}
+my $C_DATA = do { local $/; JSON->decode(<DATA>); };{{/cdata}}{{#plan}}
 plan {{&plan}};{{#plan_comment}} {{&plan_comment}}{{/plan_comment}}{{/plan}}
 {{#subs}}
 imported_ok qw({{&subs}}) or bail_out;{{/subs}}{{#methods}}


### PR DESCRIPTION
The utf8 flag on JSON results in the following error in combination with Test2::V0:
malformed UTF-8 character in JSON string

https://metacpan.org/pod/JSON::PP#ENCODING/CODESET-FLAG-NOTES

Canonical data typically does not have non-ascii characters so this is currently, for the most part, not an issue, but an exercise is currently in development to work with UTF-8.