### PR TITLE
Add trusty dist to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: false
+dist: trusty
 language: perl
 perl:
   - '5.28'


### PR DESCRIPTION
Trusty was the default, but it seems to have flipped to Xenial and is causing the builds to fail for older perl versions.