### PR TITLE
Make Clock stub Moo appropriate

### DIFF
--- a/exercises/clock/.meta/exercise-data.yaml
+++ b/exercises/clock/.meta/exercise-data.yaml
@@ -59,11 +59,12 @@ tests: |-
     }
   };
 
+moo: true
+
 stub: |-
-  sub new {
-    my ($class, $attributes) = @_;
-    return bless $attributes, $class;
-  }
+  # rwp = read-write protected
+  has hour   => ( is => 'rwp' );
+  has minute => ( is => 'rwp' );
 
   sub time {
     my ($self) = @_;
@@ -80,7 +81,6 @@ stub: |-
     return undef;
   }
 
-moo: true
 example: |-
   use POSIX ();
 

--- a/exercises/clock/Clock.pm
+++ b/exercises/clock/Clock.pm
@@ -1,10 +1,9 @@
 package Clock;
 use Moo;
 
-sub new {
-  my ( $class, $attributes ) = @_;
-  return bless $attributes, $class;
-}
+# rwp = read-write protected
+has hour   => ( is => 'rwp' );
+has minute => ( is => 'rwp' );
 
 sub time {
   my ($self) = @_;


### PR DESCRIPTION
*someone* (me) forgot to update the stub for this exercise to be appropriate for Moo. The new method is not needed.