### PR TITLE
Add explicit .perltidyrc path to generator

### DIFF
--- a/lib/Exercism/Generator.pm
+++ b/lib/Exercism/Generator.pm
@@ -65,7 +65,8 @@ sub _render {
   Perl::Tidy::perltidy(
     source      => \$rendered,
     argv        => '',
-    destination => \my $tidied
+    perltidyrc  => BASE_DIR->child('.perltidyrc')->stringify,
+    destination => \my $tidied,
   );
   return $tidied;
 }


### PR DESCRIPTION
This is to ensure the track .perltidyrc file is used if the generator is run from other locations.