### PR TITLE
Add problem-specifications submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,11 @@
 tmp
 bin/configlet
 bin/configlet.exe
+
+# Carton-installed files
+local/
+cpanfile.snapshot
+
+# Ditto, for exercises
+**/cpanfile.snapshot
+**/local/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "problem-specifications"]
+	path = problem-specifications
+	url = https://github.com/exercism/problem-specifications.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,13 +12,13 @@ perl:
   - '5.16'
   - '5.14'
 install:
+  - git submodule update --init --recursive
   - wget -P ~/bin https://git.io/cpm
   - chmod +x ~/bin/cpm
   - cpm install
   - cpm install -g App::Yath Carton Test2::V0
   - carton install
   - for i in exercises/*/.meta/solutions; do cd $i; if [ -f cpanfile ]; then echo "$i"; cpm install; fi; cd - > /dev/null; done
-  - git clone https://github.com/exercism/problem-specifications.git
   - bin/fetch-configlet
 script:
   - bin/configlet lint . --track-id=perl5


### PR DESCRIPTION
This is to make it easier to follow the instructions in bin/README.md.  After cloning, you can do `git submodule update --init --recursive` to fetch the problem-specifications repo.

I also updated .gitignore to ignore files installed by carton.  That was another thing I noticed while starting to work on converting exercises to use the generator.

Thank you for considering this PR!

