### PR TITLE
Add sshine as 'contributing maintainer'

### DIFF
--- a/config/maintainers.json
+++ b/config/maintainers.json
@@ -30,6 +30,16 @@
       "link_url": "https://github.com/rfilipo",
       "avatar_url": "https://avatars1.githubusercontent.com/u/225425?s=460&v=4",
       "bio": "Under development. Perl Monger since 1998."
+    },
+    {
+      "github_username": "sshine",
+      "alumnus": false,
+      "show_on_website": false,
+      "name": "Simon Shine",
+      "link_text": "https://simonshine.dk/",
+      "link_url": "https://simonshine.dk/",
+      "avatar_url": null,
+      "bio": null
     }
 
   ]


### PR DESCRIPTION
In response to #337, hereby adding myself as 'contributing maintainer' for the Perl 5 track. This entails `"show_on_website": false`. The context of a contributing maintainer is elaborated in a similar request made on exercism/haskell#890. Reiterating the purpose:

> *[...]* We need people to do this as the team membership *[of the repo
> exercism/v3]* is based on this and we need people in the right teams
> for assigning to issues, and Code Owners *[in the exercism/v3 repo]*.