### PR TITLE
Avoid extra number conversions

### DIFF
--- a/exercises/grains/.meta/exercise-data.yaml
+++ b/exercises/grains/.meta/exercise-data.yaml
@@ -2,7 +2,6 @@ exercise: Grains
 plan: 12
 subs: grains_on_square total_grains
 modules:
-  - use: Math::BigFloat
 tests: |-
 
   for my $case ( map @{ $_->{cases} // [$_] }, @{ $C_DATA->{cases} } ) {
@@ -13,15 +12,15 @@ tests: |-
     }
     elsif ( $case->{property} eq 'square' ) {
       is(
-        Math::BigFloat->new( grains_on_square($case->{input}{square}) )->numify,
-        number($case->{expected}),
+        grains_on_square($case->{input}{square}),
+        $case->{expected},
         'square no. ' . $case->{description}
       );
     }
     elsif ( $case->{property} eq 'total' ) {
       is(
-        Math::BigFloat->new( total_grains() )->numify,
-        number($case->{expected}),
+        total_grains(),
+        $case->{expected},
         $case->{description}
       );
     }

--- a/exercises/grains/grains.t
+++ b/exercises/grains/grains.t
@@ -19,18 +19,11 @@ for my $case ( map @{ $_->{cases} // [$_] }, @{ $C_DATA->{cases} } ) {
       $case->{description};
   }
   elsif ( $case->{property} eq 'square' ) {
-    is(
-      grains_on_square( $case->{input}{square} ),
-      $case->{expected},
-      'square no. ' . $case->{description}
-    );
+    is( grains_on_square( $case->{input}{square} ),
+      $case->{expected}, 'square no. ' . $case->{description} );
   }
   elsif ( $case->{property} eq 'total' ) {
-    is(
-      total_grains(),
-      $case->{expected},
-      $case->{description}
-    );
+    is( total_grains(), $case->{expected}, $case->{description} );
   }
 }
 

--- a/exercises/grains/grains.t
+++ b/exercises/grains/grains.t
@@ -6,7 +6,6 @@ use FindBin qw($Bin);
 use lib $Bin, "$Bin/local/lib/perl5";
 
 use Grains qw(grains_on_square total_grains);
-use Math::BigFloat;
 
 my $C_DATA = do { local $/; decode_json(<DATA>); };
 plan 12;
@@ -21,17 +20,15 @@ for my $case ( map @{ $_->{cases} // [$_] }, @{ $C_DATA->{cases} } ) {
   }
   elsif ( $case->{property} eq 'square' ) {
     is(
-      Math::BigFloat->new(
-        grains_on_square( $case->{input}{square} )
-      )->numify,
-      number( $case->{expected} ),
+      grains_on_square( $case->{input}{square} ),
+      $case->{expected},
       'square no. ' . $case->{description}
     );
   }
   elsif ( $case->{property} eq 'total' ) {
     is(
-      Math::BigFloat->new( total_grains() )->numify,
-      number( $case->{expected} ),
+      total_grains(),
+      $case->{expected},
       $case->{description}
     );
   }


### PR DESCRIPTION
We don't need BigFloat magic here as Grains.pm will always return bigints.

This should fix #239 and #240.