### PR TITLE
Include robot-name updates in generator data

### DIFF
--- a/exercises/practice/robot-name/.meta/exercise-data.yaml
+++ b/exercises/practice/robot-name/.meta/exercise-data.yaml
@@ -14,14 +14,15 @@ tests: |-
   my $robot = RobotName->new;
   isa_ok $robot, 'RobotName';
 
-  my $name  = $robot->name;
-  like $robot->name, qr/^[A-Z]{2}[0-9]{3}$/, 'Name should match schema';
+  my $name = $robot->name;
+  my $schema = qr/^[A-Z]{2}[0-9]{3}$/;
+  like $robot->name, $schema, 'Name should match schema';
   is $name, $robot->name, 'Name should be persistent';
   isnt $robot->name, RobotName->new->name,
     'Robots should have different names';
   isnt $robot->reset_name, $name,
     'reset_name should change the robot name';
-  ok $robot->name, 'reset_name should not leave the name empty';
+  like $robot->name, $schema, 'New name should match schema';
 
 example: |-
   # Declare a "name" attribute that is is 'rwp', read-write protected:

--- a/exercises/practice/robot-name/robot-name.t
+++ b/exercises/practice/robot-name/robot-name.t
@@ -13,11 +13,12 @@ can_ok 'RobotName', qw(new name reset_name) or bail_out;
 my $robot = RobotName->new;
 isa_ok $robot, 'RobotName';
 
-my $name = $robot->name;
-like $robot->name, qr/^[A-Z]{2}[0-9]{3}$/, 'Name should match schema';
+my $name   = $robot->name;
+my $schema = qr/^[A-Z]{2}[0-9]{3}$/;
+like $robot->name, $schema, 'Name should match schema';
 is $name, $robot->name, 'Name should be persistent';
 isnt $robot->name, RobotName->new->name,
   'Robots should have different names';
 isnt $robot->reset_name, $name,
   'reset_name should change the robot name';
-ok $robot->name, 'reset_name should not leave the name empty';
+like $robot->name, $schema, 'New name should match schema';


### PR DESCRIPTION
Tests for `robot-name` were changed in PR https://github.com/exercism/perl5/pull/364, but they were done outside of the exercise generator. The changes have now been incorporated into the exercise data, and the generator run to perform other updates.