### PR TITLE
[v3] Update Markdown files to latest spec

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -1,3 +1,5 @@
+# Readme
+
 The `exercise-gen.pl` file can be used in the following ways:
 * From within the directory of the exercise you wish to generate a test for.
 * With arguments specifying which exercises you want to generate tests for.  

--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -1,3 +1,5 @@
+# About
+
 Perl v5 is a high-level general purpose programming language invented by Larry Wall and first released in 1987.
 It is an eclectic interpreted, procedural, loosely typed language.
 Its popularity peaked with the rise of the World Wide Web, though it remains widely used in Quality Assurance, IT infrastructure automation, text processing, bioinformatics and web application development, just to name a few areas.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,3 +1,5 @@
+# Installation
+
 #### Unix/Linux/Mac OSX
 Perl 5 is likely already installed. Run `perl -v` to check which version you have.
 If your version is older than v5.14.0, or you would like to try out newer versions

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,6 +1,6 @@
 # Installation
 
-#### Unix/Linux/Mac OSX
+## Unix/Linux/Mac OSX
 Perl 5 is likely already installed. Run `perl -v` to check which version you have.
 If your version is older than v5.14.0, or you would like to try out newer versions
 of Perl 5, take a look at 'Other Options'.
@@ -8,7 +8,7 @@ of Perl 5, take a look at 'Other Options'.
 If you are using Fedora/Red Hat/CentOS, some core modules are not included with Perl.
 Use the `yum install perl-core` command to install them.
 
-#### Windows
+## Windows
 [Strawberry Perl](http://strawberryperl.com/): A 100% Open Source Perl for
 Windows that is exactly the same as Perl everywhere else; this includes using
 modules from CPAN, without the need for binary packages.
@@ -16,7 +16,7 @@ modules from CPAN, without the need for binary packages.
 You can either install this directly from the site or use the
 [chocolatey package manager](https://chocolatey.org/packages/StrawberryPerl).
 
-#### Other Options
+## Other Options
 * [perlbrew](https://perlbrew.pl/): A tool to manage multiple perl installations
   in your `$HOME` directory. They are completely isolated perl universes.
 * [plenv](https://github.com/tokuhirom/plenv): Installs perls under your home

--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -1,1 +1,3 @@
+# Learning
+
 Exercism provides exercises and feedback but can be difficult to jump into for those learning Perl for the first time. Check out [learn.perl.org](http://learn.perl.org/) for instructions and information on getting started with Perl 5.

--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -1,3 +1,5 @@
+# Resources
+
 ### Modules
 
 Perl 5 comes equipped with a set of core modules which you can find

--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -1,6 +1,6 @@
 # Resources
 
-### Modules
+## Modules
 
 Perl 5 comes equipped with a set of core modules which you can find
 listed on [perldoc](https://perldoc.pl/modules). Typically you will be
@@ -13,7 +13,7 @@ useful modules, and also refers to a selection of other lists of recommendations
 There are several module installers available for Perl 5, which will allow
 you to install a wide variety of modules available on [CPAN](https://metacpan.org/).
 
-#### App::cpm
+### App::cpm
 A very fast and straightforward module installer.
 There is a tutorial available on [CPAN](https://metacpan.org/pod/App::cpm::Tutorial).
 
@@ -27,7 +27,7 @@ or suggested modules respectively.
 Run `cpm install Module::Name` to install a specific module locally, or
 run `cpm install -g Module::Name` to install globally.
 
-#### App::cpanminus
+### App::cpanminus
 The most well-known and commonly used module installer available.
 Instructions for installation can be found on [CPAN](https://metacpan.org/pod/App::cpanminus).
 

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -1,6 +1,6 @@
 # Tests
 
-### Run All Tests
+## Run All Tests
 
 There is a Perl 5 script with the extension `.t`, which will be used to test
 your solution. You can run through the tests by using the command:

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -1,3 +1,5 @@
+# Tests
+
 ### Run All Tests
 
 There is a Perl 5 script with the extension `.t`, which will be used to test


### PR DESCRIPTION
We've defined a [specification for Markdown files](https://github.com/exercism/docs/blob/main/contributing/standards/markdown.md) to be applied Exercism-wide. This standard includes, amongst others, the following two rules:

- All files must start start with a level-1 heading (`# Some heading text`)
- No heading may decend a level greater than one below the previous (e.g. `## may only be followed by ###, not ####`)

This PR applies the above two rules to the Markdown documents in this repo. 

## Tracking

https://github.com/exercism/v3-launch/issues/17
