### PR TITLE
🤖 Add file patterns to config.json

### DIFF
--- a/config.json
+++ b/config.json
@@ -18,16 +18,16 @@
   "test_pattern": ".*\\.t$",
   "files": {
     "solution": [
-      "path/to/%{kebab_slug}.ext"
+      "%{pascal_slug}.pm"
     ],
     "test": [
-      "path/to/%{kebab_slug}.ext"
+      "%{kebab_slug}.t"
     ],
     "example": [
-      "path/to/%{kebab_slug}.ext"
+      "%{pascal_slug}.pm"
     ],
     "exemplar": [
-      "path/to/%{kebab_slug}.ext"
+      "%{kebab_slug}.t"
     ]
   },
   "exercises": {

--- a/config.json
+++ b/config.json
@@ -24,10 +24,10 @@
       "%{kebab_slug}.t"
     ],
     "example": [
-      "%{pascal_slug}.pm"
+      ".meta/solutions/%{pascal_slug}.pm"
     ],
     "exemplar": [
-      "%{kebab_slug}.t"
+      ".meta/solutions/%{kebab_slug}.t"
     ]
   },
   "exercises": {

--- a/config.json
+++ b/config.json
@@ -27,7 +27,7 @@
       ".meta/solutions/%{pascal_slug}.pm"
     ],
     "exemplar": [
-      ".meta/solutions/%{kebab_slug}.t"
+      ".meta/%{pascal_slug}.pm"
     ]
   },
   "exercises": {

--- a/config.json
+++ b/config.json
@@ -16,6 +16,20 @@
   },
   "solution_pattern": "\\.meta/solutions/.+\\.pm$",
   "test_pattern": ".*\\.t$",
+  "files": {
+    "solution": [
+      "path/to/%{kebab_slug}.ext"
+    ],
+    "test": [
+      "path/to/%{kebab_slug}.ext"
+    ],
+    "example": [
+      "path/to/%{kebab_slug}.ext"
+    ],
+    "exemplar": [
+      "path/to/%{kebab_slug}.ext"
+    ]
+  },
   "exercises": {
     "concept": [],
     "practice": [


### PR DESCRIPTION
**⚠ This PR requires you to make a simple change before merging. ⚠**

---

To save maintainers from having to manually specify the `files` key in their exercises' `.meta/config.json` files, we are providing support for track-level patterns. See [this PR](https://github.com/exercism/docs/pull/58) for details.

This PR adds (**purposefully wrong**) file patterns to the `config.json` file. It is up to you, the track maintainers, to change these patterns to their correct value.

You can use the following placeholders:
- `%{kebab_slug}`: the `kebab-case` exercise slug (e.g. `bit-manipulation`)
- `%{snake_slug}`: the `snake_case` exercise slug (e.g. `bit_manipulation`)
- `%{camel_slug}`: the `camelCase` exercise slug (e.g. `bitManipulation`)
- `%{pascal_slug}`: the `PascalCase` exercise slug (e.g. `BitManipulation`)

We will soon update `configlet` to enable it to automatically populate the `.meta/config.json` file's `files` property, at which point we will then batch-PR updates to all tracks that have merged this PR.

## Tracking
https://github.com/exercism/v3-launch/issues/19
