### PR TITLE
Update generator to accept old and new tests.toml formats

### DIFF
--- a/lib/Exercism/Generator.pm
+++ b/lib/Exercism/Generator.pm
@@ -163,9 +163,20 @@ sub _build_case_uuids {
   my $toml_data;
   if ( $toml_file->is_file ) {
     $toml_data = TOML::Parser->new->parse( $toml_file->slurp_utf8 );
+
+    # TODO: Remove old toml format
+    if ( exists $toml_data->{'canonical-tests'} ) {
+      return [
+        grep { $toml_data->{'canonical-tests'}{$_} }
+          keys %{ $toml_data->{'canonical-tests'} }
+      ];
+    }
+
     return [
-      grep { $toml_data->{'canonical-tests'}{$_} }
-        keys %{ $toml_data->{'canonical-tests'} }
+      grep {
+        !exists( $toml_data->{$_}{include} )
+          || $toml_data->{$_}{include}
+      } keys %{$toml_data}
     ];
   }
 

--- a/t/files/generated-tests.t
+++ b/t/files/generated-tests.t
@@ -18,7 +18,7 @@ for ( sort { $a cmp $b }
 {
   if ( $_->child( '.meta', 'exercise-data.yaml' )->is_file ) {
     is(
-      [ split( /\n/, $_->child( $_->basename . '.t' )->slurp ) ],
+      [ split( /\n/, $_->child( $_->basename . '.t' )->slurp_utf8 ) ],
       [ split(
           /\n/,
           Exercism::Generator->new(


### PR DESCRIPTION
Done according to the spec in https://github.com/exercism/configlet/issues/198. Expects `include` to either not exist or be true.