### PR TITLE
One test added to word-count task

### DIFF
--- a/exercises/practice/word-count/word-count.t
+++ b/exercises/practice/word-count/word-count.t
@@ -186,5 +186,18 @@ __DATA__
       "sentence": ",\n,one,\n ,two \n 'three'"
     },
     "property": "countWords"
+  },
+  {
+    "description": "several words are quouted, including first and last",
+    "expected": {
+      "one": 1,
+      "three": 1,
+      "two": 1,
+      "and": 1
+    },
+    "input": {
+      "sentence": "'one', 'two' and 'three'"
+    },
+    "property": "countWords"
   }
 ]


### PR DESCRIPTION
When solving this task I forgot to add g at the end of 
```
$s =~s/[^0-9a-z]'+/ /;
```
and was quite surprised to see all test passed, as all test entries has only single quoted word in them. I think we should improve the test.

------

If you choose to solve this task using regexp, you may forgot putting "g" at the end of the s///; To catch this mistake you we need test with several words quoted in single quotes.

First and last word is a special cases go regexp solution, so add them here too.