### PR TITLE
Refactor binary-search-tree to not use subtests

### DIFF
--- a/exercises/practice/binary-search-tree/.meta/exercise-data.yaml
+++ b/exercises/practice/binary-search-tree/.meta/exercise-data.yaml
@@ -1,24 +1,23 @@
 subs: tree treeSort
+plan: 11
 tests: |-
-  subtest data => sub {
-    for my $case (grep {$_->{property} eq 'data'} @test_cases) {
+  for my $case (@test_cases) {
+    if ($case->{property} eq 'data') {
       is(
         tree($case->{input}{treeData}),
         $case->{expected},
         $case->{description},
       );
     }
-  };
 
-  subtest sorting => sub {
-    for my $case (grep {$_->{property} eq 'sortedData'} @test_cases) {
+    elsif ($case->{property} eq 'sortedData') {
       is(
         treeSort($case->{input}{treeData}),
         $case->{expected},
         $case->{description},
       );
     }
-  };
+  }
 
 example: |-
   sub tree {

--- a/exercises/practice/binary-search-tree/binary-search-tree.t
+++ b/exercises/practice/binary-search-tree/binary-search-tree.t
@@ -14,15 +14,15 @@ plan 11;
 imported_ok qw<tree treeSort> or bail_out;
 
 for my $case (@test_cases) {
-  if ( $case->{property} eq 'data' ) {
-    is( tree( $case->{input}{treeData} ),
-      $case->{expected}, $case->{description}, );
-  }
+    if ( $case->{property} eq 'data' ) {
+        is( tree( $case->{input}{treeData} ),
+            $case->{expected}, $case->{description}, );
+    }
 
-  elsif ( $case->{property} eq 'sortedData' ) {
-    is( treeSort( $case->{input}{treeData} ),
-      $case->{expected}, $case->{description}, );
-  }
+    elsif ( $case->{property} eq 'sortedData' ) {
+        is( treeSort( $case->{input}{treeData} ),
+            $case->{expected}, $case->{description}, );
+    }
 }
 
 __DATA__

--- a/exercises/practice/binary-search-tree/binary-search-tree.t
+++ b/exercises/practice/binary-search-tree/binary-search-tree.t
@@ -9,25 +9,21 @@ use lib $Bin, "$Bin/local/lib/perl5";
 use BinarySearchTree qw<tree treeSort>;
 
 my @test_cases = do { local $/; @{ JSON->decode(<DATA>) }; };
+plan 11;
 
 imported_ok qw<tree treeSort> or bail_out;
 
-subtest data => sub {
-  for my $case ( grep { $_->{property} eq 'data' } @test_cases ) {
+for my $case (@test_cases) {
+  if ( $case->{property} eq 'data' ) {
     is( tree( $case->{input}{treeData} ),
       $case->{expected}, $case->{description}, );
   }
-};
 
-subtest sorting => sub {
-  for my $case ( grep { $_->{property} eq 'sortedData' } @test_cases )
-  {
+  elsif ( $case->{property} eq 'sortedData' ) {
     is( treeSort( $case->{input}{treeData} ),
       $case->{expected}, $case->{description}, );
   }
-};
-
-done_testing;
+}
 
 __DATA__
 [


### PR DESCRIPTION
@exercism/reviewers Subtests are currently not supported in the test runner. The new loop also ensures the tests run in the expected order.