### PR TITLE
Do not exit test on die

### DIFF
--- a/exercises/practice/phone-number/phone-number.t
+++ b/exercises/practice/phone-number/phone-number.t
@@ -15,8 +15,10 @@ imported_ok qw<clean_number> or bail_out;
 
 for my $case (@test_cases) {
     if ( !ref $case->{expected} ) {
-        is clean_number( $case->{input}{phrase} ), $case->{expected},
-            $case->{description};
+        lives {
+            is clean_number( $case->{input}{phrase} ), $case->{expected},
+                $case->{description};
+        }
     }
     else {
         like dies( sub { clean_number( $case->{input}{phrase} ) } ),


### PR DESCRIPTION
Add a `lives` check when expecting a successful result in tests. This ensures the tests don't stop abruptly with an error, which is very confusing - especially for beginners.

With this change, tests will always execute as expected, even if the program `die`s when it shouldn't, instead of exiting.