### PR TITLE
Convert `average_run_time` to an integer

### DIFF
--- a/config.json
+++ b/config.json
@@ -16,7 +16,7 @@
     "highlightjs_language": "perl"
   },
   "test_runner": {
-    "average_run_time": 2.0
+    "average_run_time": 2
   },
   "files": {
     "solution": [


### PR DESCRIPTION
Convert `average_run_time` to an integer.

There are two reasons for this change:

1. Having the average run time as a float gives the impression of being exact, whereas the actual run time wildly varies due to a wide variety of reasons (e.g. how busy it is on the server). That fractional component will almost never actually conform the real situation.

2. jq is often used to work with track config.json config files (e.g. to add elements to it), and it will remove any trailing .0 fractional part from a number, which caused configlet lint to fail. Those JQ scripts then have to work around this by manually adding .0 to it.

This PR has been created as a draft and we will automatically merge it next week once the new `configlet` release is out.

See https://github.com/exercism/docs/pull/430 for more information.