### PR TITLE
CI: pin GitHub Actions runners

### DIFF
--- a/.github/workflows/exercises.yml
+++ b/.github/workflows/exercises.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ['ubuntu-latest', 'macos-latest']
+        os: ['ubuntu-22.04', 'macos-12']
         perl: ['5.38', '5.36', '5.34', '5.32', '5.30', '5.28', '5.26', '5.24', '5.22', '5.20']
         include:
-          - os: 'windows-latest'
+          - os: 'windows-2022'
             perl: '5.32'
 
     name: Perl ${{ matrix.perl }} on ${{ matrix.os }}

--- a/.github/workflows/generator.yml
+++ b/.github/workflows/generator.yml
@@ -7,7 +7,7 @@ jobs:
   generator:
     env:
       TS_MAX_DELTA: 3
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
This PR updates GitHub Actions runners to a specific version.
This ensures that the workflow will always run on the same runner, which makes your build _stable_.

The PR updates the *-latest version with the current version, as specified in https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources.

See https://exercism.org/docs/building/github/gha-best-practices#h-pin-test-runners-to-version for more information.