### PR TITLE
Update installation notes and stubs for older versions of Perl

### DIFF
--- a/concepts/packages-and-modules/about.md
+++ b/concepts/packages-and-modules/about.md
@@ -7,7 +7,7 @@ Symbols in the package's `@EXPORT` array will be imported by default.
 Symbols in the package's `@EXPORT_OK` array must be imported explicitly.
 
 Before Perl `v5.37`, a module would have to end in a true value (usually `1`) to indicate the module had loaded successfully.
-This is no longer necessary when using the [`module_true`][module_true] feature.
+This is not necessary when using the [`module_true`][module_true] feature.
 
 ## Exporting
 

--- a/concepts/packages-and-modules/introduction.md
+++ b/concepts/packages-and-modules/introduction.md
@@ -7,7 +7,7 @@ Symbols in the package's `@EXPORT` array will be imported by default.
 Symbols in the package's `@EXPORT_OK` array must be imported explicitly.
 
 Before Perl `v5.37`, a module would have to end in a true value (usually `1`) to indicate the module had loaded successfully.
-This is no longer necessary when using the [`module_true`][module_true] feature.
+This is not necessary when using the [`module_true`][module_true] feature.
 
 ## Exporting
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,8 +1,19 @@
 # Installation
 
+## Perl Version Notes
+The track targets the latest stable release of Perl, but it is possible to use versions of Perl as old as 5.20.
+If you are unable to use the latest version, it is recomended to replace `use v5.XX` with the following code:
+
+```perl
+use strict;
+use warnings;
+use feature qw<signatures>;
+```
+
 ## Unix/Linux/Mac OSX
-Perl is likely already installed. Run `perl -v` to check which version you have.
-If your version is older than v5.20, or you would like to try out newer versions of Perl, take a look at 'Other Options'.
+Perl is likely already installed, however it is possible that this may not be the latest version.
+Run `perl -v` to check which version you have.
+If you wish to use a later version, check the 'Other Options' section.
 
 If you are using Fedora/Red Hat/CentOS, some core modules are not included with Perl.
 Use the `yum install perl-core` command to install them.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -2,7 +2,7 @@
 
 ## Perl Version Notes
 The track targets the latest stable release of Perl, but it is possible to use versions of Perl as old as 5.20.
-If you are unable to use the latest version, it is recomended to replace `use v5.XX` with the following code:
+If you are unable to use the version specified in the stub files, it is recomended to replace `use v5.XX;` with the following code:
 
 ```perl
 use strict;

--- a/exercises/concept/booking-up-for-beauty/lib/BookingUpForBeauty.pm
+++ b/exercises/concept/booking-up-for-beauty/lib/BookingUpForBeauty.pm
@@ -35,3 +35,5 @@ sub describe_appointment ($date_string) {
     my $time = _parse_datetime($date_string);
     return sprintf('You have an appointment on %02d/%02d/%04d %d:%02d %s', 1, 31, 2019, 6, 4, 'PM');
 }
+
+1;

--- a/exercises/concept/high-score-board/lib/HighScoreBoard.pm
+++ b/exercises/concept/high-score-board/lib/HighScoreBoard.pm
@@ -21,3 +21,5 @@ sub sort_players_by_score {
 
 sub delete_player ($player) {
 }
+
+1;

--- a/exercises/concept/inventory-management/lib/InventoryManagement.pm
+++ b/exercises/concept/inventory-management/lib/InventoryManagement.pm
@@ -18,3 +18,5 @@ sub remove_items ( $inventory, $items ) {
 sub delete_item ( $inventory, $item ) {
     return $inventory;
 }
+
+1;

--- a/exercises/concept/language-list/lib/LanguageList.pm
+++ b/exercises/concept/language-list/lib/LanguageList.pm
@@ -21,3 +21,5 @@ sub get_languages (@elements) {
 
 sub has_language ($language) {
 }
+
+1;

--- a/exercises/concept/lasagna/lib/Lasagna.pm
+++ b/exercises/concept/lasagna/lib/Lasagna.pm
@@ -15,3 +15,5 @@ sub total_time_in_minutes ( $number_of_layers, $actual_minutes_in_oven ) {
 
 sub oven_alarm () {
 }
+
+1;

--- a/exercises/practice/accumulate/lib/Accumulate.pm
+++ b/exercises/practice/accumulate/lib/Accumulate.pm
@@ -8,3 +8,5 @@ our @EXPORT_OK = qw<accumulate>;
 sub accumulate ( $list, $func ) {
     return undef;
 }
+
+1;

--- a/exercises/practice/all-your-base/lib/AllYourBase.pm
+++ b/exercises/practice/all-your-base/lib/AllYourBase.pm
@@ -14,3 +14,5 @@ my @errors = (
 sub rebase ( $digits, $input_base, $output_base ) {
     return undef;
 }
+
+1;

--- a/exercises/practice/allergies/lib/Allergies.pm
+++ b/exercises/practice/allergies/lib/Allergies.pm
@@ -12,3 +12,5 @@ sub allergic_to ( $item, $score ) {
 sub list_allergies ($score) {
     return undef;
 }
+
+1;

--- a/exercises/practice/anagram/lib/Anagram.pm
+++ b/exercises/practice/anagram/lib/Anagram.pm
@@ -8,3 +8,5 @@ our @EXPORT_OK = qw<match_anagrams>;
 sub match_anagrams ( $subject, $candidates ) {
     return undef;
 }
+
+1;

--- a/exercises/practice/atbash-cipher/lib/AtbashCipher.pm
+++ b/exercises/practice/atbash-cipher/lib/AtbashCipher.pm
@@ -12,3 +12,5 @@ sub encode_atbash ($phrase) {
 sub decode_atbash ($phrase) {
     return undef;
 }
+
+1;

--- a/exercises/practice/binary-search-tree/lib/BinarySearchTree.pm
+++ b/exercises/practice/binary-search-tree/lib/BinarySearchTree.pm
@@ -26,3 +26,5 @@ sub add ($self) {
 sub sort ($self) {
     return [];
 }
+
+1;

--- a/exercises/practice/binary-search/lib/BinarySearch.pm
+++ b/exercises/practice/binary-search/lib/BinarySearch.pm
@@ -8,3 +8,5 @@ our @EXPORT_OK = qw<binary_search>;
 sub binary_search ( $array, $value ) {
     return undef;
 }
+
+1;

--- a/exercises/practice/bob/lib/Bob.pm
+++ b/exercises/practice/bob/lib/Bob.pm
@@ -9,3 +9,5 @@ our @EXPORT_OK = qw<hey>;
 sub hey ($msg) {
     return undef; # Replace this with your own code to pass the tests.
 }
+
+1;

--- a/exercises/practice/bottle-song/lib/BottleSong.pm
+++ b/exercises/practice/bottle-song/lib/BottleSong.pm
@@ -21,3 +21,5 @@ my %numbers = (
 sub sing ( $bottles, $verses ) {
     return undef;
 }
+
+1;

--- a/exercises/practice/clock/lib/Clock.pm
+++ b/exercises/practice/clock/lib/Clock.pm
@@ -18,3 +18,5 @@ sub add_minutes ( $self, $amount ) {
 sub subtract_minutes ( $self, $amount ) {
     return $self;
 }
+
+1;

--- a/exercises/practice/crypto-square/lib/CryptoSquare.pm
+++ b/exercises/practice/crypto-square/lib/CryptoSquare.pm
@@ -8,3 +8,5 @@ our @EXPORT_OK = qw<cipher>;
 sub cipher ($text) {
     return undef;
 }
+
+1;

--- a/exercises/practice/custom-set/lib/CustomSet.pm
+++ b/exercises/practice/custom-set/lib/CustomSet.pm
@@ -47,3 +47,5 @@ sub difference ( $self, $other ) {
 sub union ( $self, $other ) {
     return undef;
 }
+
+1;

--- a/exercises/practice/darts/lib/Darts.pm
+++ b/exercises/practice/darts/lib/Darts.pm
@@ -7,3 +7,5 @@ our @EXPORT_OK = qw<score_dart>;
 
 sub score_dart ( $x, $y ) {
 }
+
+1;

--- a/exercises/practice/difference-of-squares/lib/DifferenceOfSquares.pm
+++ b/exercises/practice/difference-of-squares/lib/DifferenceOfSquares.pm
@@ -16,3 +16,5 @@ sub sum_of_squares ($number) {
 sub difference_of_squares ($number) {
     return undef;
 }
+
+1;

--- a/exercises/practice/etl/lib/ETL.pm
+++ b/exercises/practice/etl/lib/ETL.pm
@@ -8,3 +8,5 @@ our @EXPORT_OK = qw<transform>;
 sub transform ($data) {
     return undef;
 }
+
+1;

--- a/exercises/practice/food-chain/lib/FoodChain.pm
+++ b/exercises/practice/food-chain/lib/FoodChain.pm
@@ -8,3 +8,5 @@ our @EXPORT_OK = qw<recite>;
 sub recite ( $start, $end ) {
     return undef;
 }
+
+1;

--- a/exercises/practice/gigasecond/lib/Gigasecond.pm
+++ b/exercises/practice/gigasecond/lib/Gigasecond.pm
@@ -9,3 +9,4 @@ sub add_gigasecond ($time) {
     return undef;
 }
 
+1;

--- a/exercises/practice/grade-school/lib/GradeSchool.pm
+++ b/exercises/practice/grade-school/lib/GradeSchool.pm
@@ -10,3 +10,5 @@ sub add ( $self, $student, $grade ) {
 sub roster ( $self, $grade = undef ) {
     return undef;
 }
+
+1;

--- a/exercises/practice/grains/lib/Grains.pm
+++ b/exercises/practice/grains/lib/Grains.pm
@@ -12,3 +12,5 @@ sub grains_on_square ($square) {
 sub total_grains () {
     return undef;
 }
+
+1;

--- a/exercises/practice/hamming/lib/Hamming.pm
+++ b/exercises/practice/hamming/lib/Hamming.pm
@@ -8,3 +8,5 @@ our @EXPORT_OK = qw<hamming_distance>;
 sub hamming_distance ( $strand1, $strand2 ) {
     return undef;
 }
+
+1;

--- a/exercises/practice/hello-world/lib/HelloWorld.pm
+++ b/exercises/practice/hello-world/lib/HelloWorld.pm
@@ -9,3 +9,5 @@ our @EXPORT_OK = qw<hello>;
 sub hello () {
     return 'Goodbye, Mars!';
 }
+
+1;

--- a/exercises/practice/house/lib/House.pm
+++ b/exercises/practice/house/lib/House.pm
@@ -8,3 +8,5 @@ our @EXPORT_OK = qw<recite>;
 sub recite ( $start, $end ) {
     return undef;
 }
+
+1;

--- a/exercises/practice/kindergarten-garden/lib/KindergartenGarden.pm
+++ b/exercises/practice/kindergarten-garden/lib/KindergartenGarden.pm
@@ -15,3 +15,5 @@ sub plants ( $diagram, $student ) {
 
     return undef;
 }
+
+1;

--- a/exercises/practice/largest-series-product/lib/LargestSeriesProduct.pm
+++ b/exercises/practice/largest-series-product/lib/LargestSeriesProduct.pm
@@ -8,3 +8,5 @@ our @EXPORT_OK = qw<largest_product>;
 sub largest_product ( $digits, $span ) {
     return undef;
 }
+
+1;

--- a/exercises/practice/leap/lib/Leap.pm
+++ b/exercises/practice/leap/lib/Leap.pm
@@ -9,3 +9,5 @@ our @EXPORT_OK = qw<is_leap_year>;
 sub is_leap_year ($year) {
     return undef; # Replace this with your own code to pass the tests.
 }
+
+1;

--- a/exercises/practice/luhn/lib/Luhn.pm
+++ b/exercises/practice/luhn/lib/Luhn.pm
@@ -8,3 +8,5 @@ our @EXPORT_OK = qw<is_luhn_valid>;
 sub is_luhn_valid ($number) {
     return undef;
 }
+
+1;

--- a/exercises/practice/matrix/lib/Matrix.pm
+++ b/exercises/practice/matrix/lib/Matrix.pm
@@ -12,3 +12,5 @@ sub extract_row ( $matrix, $row ) {
 sub extract_column ( $matrix, $column ) {
     return undef;
 }
+
+1;

--- a/exercises/practice/meetup/lib/Meetup.pm
+++ b/exercises/practice/meetup/lib/Meetup.pm
@@ -9,3 +9,4 @@ sub meetup ($desc) {
     return undef;
 }
 
+1;

--- a/exercises/practice/minesweeper/lib/Minesweeper.pm
+++ b/exercises/practice/minesweeper/lib/Minesweeper.pm
@@ -8,3 +8,5 @@ our @EXPORT_OK = qw<annotate>;
 sub annotate ($minefield) {
     return undef;
 }
+
+1;

--- a/exercises/practice/nucleotide-count/lib/NucleotideCount.pm
+++ b/exercises/practice/nucleotide-count/lib/NucleotideCount.pm
@@ -8,3 +8,5 @@ our @EXPORT_OK = qw<count_nucleotides>;
 sub count_nucleotides ($strand) {
     return undef;
 }
+
+1;

--- a/exercises/practice/ocr-numbers/lib/OCRNumbers.pm
+++ b/exercises/practice/ocr-numbers/lib/OCRNumbers.pm
@@ -8,3 +8,5 @@ our @EXPORT_OK = qw<convert_ocr>;
 sub convert_ocr ($string) {
     return undef;
 }
+
+1;

--- a/exercises/practice/palindrome-products/lib/PalindromeProducts.pm
+++ b/exercises/practice/palindrome-products/lib/PalindromeProducts.pm
@@ -12,3 +12,5 @@ sub smallest_palindrome ( $min, $max ) {
 sub largest_palindrome ( $min, $max ) {
     return undef;
 }
+
+1;

--- a/exercises/practice/pascals-triangle/lib/PascalsTriangle.pm
+++ b/exercises/practice/pascals-triangle/lib/PascalsTriangle.pm
@@ -9,3 +9,4 @@ sub pascal_rows ($rows) {
     return undef;
 }
 
+1;

--- a/exercises/practice/phone-number/lib/PhoneNumber.pm
+++ b/exercises/practice/phone-number/lib/PhoneNumber.pm
@@ -21,3 +21,4 @@ sub clean_number ($number) {
     return undef;
 }
 
+1;

--- a/exercises/practice/pig-latin/lib/PigLatin.pm
+++ b/exercises/practice/pig-latin/lib/PigLatin.pm
@@ -9,3 +9,4 @@ sub translate ($phrase) {
     return undef;
 }
 
+1;

--- a/exercises/practice/prime-factors/lib/PrimeFactors.pm
+++ b/exercises/practice/prime-factors/lib/PrimeFactors.pm
@@ -8,3 +8,5 @@ our @EXPORT_OK = qw<factors>;
 sub factors ($number) {
     return undef;
 }
+
+1;

--- a/exercises/practice/proverb/lib/Proverb.pm
+++ b/exercises/practice/proverb/lib/Proverb.pm
@@ -8,3 +8,5 @@ our @EXPORT_OK = qw<proverb>;
 sub proverb ($items) {
     return undef;
 }
+
+1;

--- a/exercises/practice/pythagorean-triplet/lib/PythagoreanTriplet.pm
+++ b/exercises/practice/pythagorean-triplet/lib/PythagoreanTriplet.pm
@@ -8,3 +8,5 @@ our @EXPORT_OK = qw<triplets_with_sum>;
 sub triplets_with_sum ($sum) {
     return undef;
 }
+
+1;

--- a/exercises/practice/queen-attack/lib/Queen.pm
+++ b/exercises/practice/queen-attack/lib/Queen.pm
@@ -14,3 +14,5 @@ has column => (
 sub can_attack ( $self, $other ) {
     return undef;
 }
+
+1;

--- a/exercises/practice/raindrops/lib/Raindrops.pm
+++ b/exercises/practice/raindrops/lib/Raindrops.pm
@@ -8,3 +8,5 @@ our @EXPORT_OK = qw<raindrop>;
 sub raindrop ($number) {
     return undef;
 }
+
+1;

--- a/exercises/practice/rna-transcription/lib/RNA.pm
+++ b/exercises/practice/rna-transcription/lib/RNA.pm
@@ -8,3 +8,5 @@ our @EXPORT_OK = qw<to_rna>;
 sub to_rna ($dna) {
     return undef;
 }
+
+1;

--- a/exercises/practice/robot-name/lib/RobotName.pm
+++ b/exercises/practice/robot-name/lib/RobotName.pm
@@ -11,3 +11,5 @@ has name => ( is => 'rwp' );
 sub reset_name ($self) {
     return undef; # Replace this with your own code to pass the tests.
 }
+
+1;

--- a/exercises/practice/robot-simulator/lib/Robot.pm
+++ b/exercises/practice/robot-simulator/lib/Robot.pm
@@ -23,3 +23,5 @@ has direction => (
 sub enact ( $self, $instructions ) {
     return $self;
 }
+
+1;

--- a/exercises/practice/roman-numerals/lib/RomanNumerals.pm
+++ b/exercises/practice/roman-numerals/lib/RomanNumerals.pm
@@ -8,3 +8,5 @@ our @EXPORT_OK = qw<to_roman>;
 sub to_roman ($number) {
     return undef;
 }
+
+1;

--- a/exercises/practice/saddle-points/lib/SaddlePoints.pm
+++ b/exercises/practice/saddle-points/lib/SaddlePoints.pm
@@ -8,3 +8,5 @@ our @EXPORT_OK = qw<saddle_points>;
 sub saddle_points ($matrix) {
     return undef;
 }
+
+1;

--- a/exercises/practice/say/lib/Say.pm
+++ b/exercises/practice/say/lib/Say.pm
@@ -8,3 +8,5 @@ our @EXPORT_OK = qw<say_number>;
 sub say_number ($number) {
     return undef;
 }
+
+1;

--- a/exercises/practice/scrabble-score/lib/Scrabble.pm
+++ b/exercises/practice/scrabble-score/lib/Scrabble.pm
@@ -8,3 +8,5 @@ our @EXPORT_OK = qw<scrabble_score>;
 sub scrabble_score ($word) {
     return undef;
 }
+
+1;

--- a/exercises/practice/secret-handshake/lib/SecretHandshake.pm
+++ b/exercises/practice/secret-handshake/lib/SecretHandshake.pm
@@ -8,3 +8,5 @@ our @EXPORT_OK = qw<handshake>;
 sub handshake ($number) {
     return undef;
 }
+
+1;

--- a/exercises/practice/series/lib/Series.pm
+++ b/exercises/practice/series/lib/Series.pm
@@ -8,3 +8,5 @@ our @EXPORT_OK = qw<slices>;
 sub slices ( $series, $slice_length ) {
     return undef;
 }
+
+1;

--- a/exercises/practice/sieve/lib/Sieve.pm
+++ b/exercises/practice/sieve/lib/Sieve.pm
@@ -8,3 +8,5 @@ our @EXPORT_OK = qw<find_primes>;
 sub find_primes ($limit) {
     return undef;
 }
+
+1;

--- a/exercises/practice/simple-cipher/lib/SimpleCipher.pm
+++ b/exercises/practice/simple-cipher/lib/SimpleCipher.pm
@@ -18,3 +18,5 @@ sub decode ($self) {
 sub _build_key ($self) {
     return undef;
 }
+
+1;

--- a/exercises/practice/space-age/lib/SpaceAge.pm
+++ b/exercises/practice/space-age/lib/SpaceAge.pm
@@ -8,3 +8,5 @@ our @EXPORT_OK = qw<age_on_planet>;
 sub age_on_planet ( $planet, $seconds ) {
     return undef;
 }
+
+1;

--- a/exercises/practice/strain/lib/Strain.pm
+++ b/exercises/practice/strain/lib/Strain.pm
@@ -12,3 +12,5 @@ sub keep ( $input, $function ) {
 sub discard ( $input, $function ) {
     return undef;
 }
+
+1;

--- a/exercises/practice/sublist/lib/Sublist.pm
+++ b/exercises/practice/sublist/lib/Sublist.pm
@@ -8,3 +8,5 @@ our @EXPORT_OK = qw<compare_lists>;
 sub compare_lists ( $list1, $list2 ) {
     return undef;
 }
+
+1;

--- a/exercises/practice/sum-of-multiples/lib/SumOfMultiples.pm
+++ b/exercises/practice/sum-of-multiples/lib/SumOfMultiples.pm
@@ -8,3 +8,5 @@ our @EXPORT_OK = qw<sum_of_multiples>;
 sub sum_of_multiples ( $factors, $limit ) {
     return undef;
 }
+
+1;

--- a/exercises/practice/triangle/lib/Triangle.pm
+++ b/exercises/practice/triangle/lib/Triangle.pm
@@ -16,3 +16,5 @@ sub is_isosceles ($triangle) {
 sub is_scalene ($triangle) {
     return undef;
 }
+
+1;

--- a/exercises/practice/twelve-days/lib/TwelveDays.pm
+++ b/exercises/practice/twelve-days/lib/TwelveDays.pm
@@ -9,3 +9,4 @@ sub recite ( $start, $end ) {
     return '';
 }
 
+1;

--- a/exercises/practice/two-fer/lib/TwoFer.pm
+++ b/exercises/practice/two-fer/lib/TwoFer.pm
@@ -8,3 +8,5 @@ our @EXPORT_OK = qw<two_fer>;
 sub two_fer ( $name = undef ) {
     return undef;
 }
+
+1;

--- a/exercises/practice/word-count/lib/WordCount.pm
+++ b/exercises/practice/word-count/lib/WordCount.pm
@@ -8,3 +8,5 @@ our @EXPORT_OK = qw<count_words>;
 sub count_words ($sentence) {
     return undef;
 }
+
+1;

--- a/exercises/practice/wordy/lib/Wordy.pm
+++ b/exercises/practice/wordy/lib/Wordy.pm
@@ -8,3 +8,5 @@ our @EXPORT_OK = qw<answer>;
 sub answer ($question) {
     return undef;
 }
+
+1;

--- a/templates/module.mustache
+++ b/templates/module.mustache
@@ -11,6 +11,6 @@ use experimental qw<signatures postderef postderef_qq>;{{/older_perl_support}}
 use Exporter qw<import>;
 our @EXPORT_OK = qw<{{&subs}}>;{{/subs}}{{#module_file}}
 
-{{&module_file}}{{/module_file}}{{#older_perl_support}}
+{{&module_file}}{{/module_file}}
 
-1;{{/older_perl_support}}
+1;


### PR DESCRIPTION
[no important files changed]

Add notes to the CLI instructions for users of older versions of Perl.

The stub files have also been updated. While ending a module in a true value is not necessary for newer versions of Perl, its mostly unobtrusive and can be removed by the user if they wish.