### PR TITLE
Update about.md

### DIFF
--- a/concepts/arrays-and-lists/about.md
+++ b/concepts/arrays-and-lists/about.md
@@ -56,7 +56,7 @@ scalar @names; # 3
 scalar ('Alice', 'Bob', 'Charlie'); # 'Charlie' (and some warnings).
 ```
 
-Read more in the following article: [What is the difference between a list and an array?](https://perldoc.pl/perlfaq4#What-is-the-difference-between-a-list-and-an-array?)
+Read more in the following article: [What is the difference between a list and an array?][perlfaq4listarray]
 
 [perlfaq4listarray]: https://perldoc.pl/perlfaq4#What-is-the-difference-between-a-list-and-an-array?
 [grep]: https://perldoc.pl/functions/grep

--- a/concepts/arrays-and-lists/about.md
+++ b/concepts/arrays-and-lists/about.md
@@ -56,7 +56,7 @@ scalar @names; # 3
 scalar ('Alice', 'Bob', 'Charlie'); # 'Charlie' (and some warnings).
 ```
 
-Read more in the folowing FAQ: [What is the difference between a list and an array?](perlfaq4listarray)
+Read more in the following article: [What is the difference between a list and an array?](https://perldoc.pl/perlfaq4#What-is-the-difference-between-a-list-and-an-array?)
 
 [perlfaq4listarray]: https://perldoc.pl/perlfaq4#What-is-the-difference-between-a-list-and-an-array?
 [grep]: https://perldoc.pl/functions/grep

--- a/concepts/arrays-and-lists/about.md
+++ b/concepts/arrays-and-lists/about.md
@@ -56,7 +56,7 @@ scalar @names; # 3
 scalar ('Alice', 'Bob', 'Charlie'); # 'Charlie' (and some warnings).
 ```
 
-Read more in the following article: [What is the difference between a list and an array?][perlfaq4listarray]
+Read more in the following FAQ: [What is the difference between a list and an array?][perlfaq4listarray]
 
 [perlfaq4listarray]: https://perldoc.pl/perlfaq4#What-is-the-difference-between-a-list-and-an-array?
 [grep]: https://perldoc.pl/functions/grep


### PR DESCRIPTION
Fix spelling error, replace dead link

The FAQ link 404s for me, and the Brian d Foy section is from the official perl4faq. Might be preferable to drop the FAQ line entirely since the same link is immediately below.