### PR TITLE
Set micro-blog as wip

### DIFF
--- a/config.json
+++ b/config.json
@@ -769,7 +769,8 @@
         "uuid": "f03e4e99-97ff-4ac7-8975-bbafa38c9088",
         "practices": [],
         "prerequisites": [],
-        "difficulty": 1
+        "difficulty": 1,
+        "status": "wip"
       }
     ]
   },


### PR DESCRIPTION
UTF8 problem to be resolved in test runner.

Fixed in https://github.com/exercism/perl5-test-runner/pull/86