### PR TITLE
Bump Perl from 5.40 to 5.42. Remove some older versions from the CI test.

### DIFF
--- a/.github/workflows/exercises.yml
+++ b/.github/workflows/exercises.yml
@@ -9,11 +9,11 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest', 'macos-latest']
-        perl: ['5.40', '5.38', '5.36', '5.34', '5.32', '5.30', '5.28', '5.26']
+        perl: ['5.42', '5.40', '5.38', '5.36', '5.34', '5.30', '5.26']
         distribution: ['default']
         include:
           - os: 'windows-latest'
-            perl: '5.40'
+            perl: '5.42'
             distribution: strawberry
 
     name: Perl ${{ matrix.perl }} on ${{ matrix.os }}

--- a/.github/workflows/exercises.yml
+++ b/.github/workflows/exercises.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest', 'macos-latest']
-        perl: ['5.42', '5.40', '5.38', '5.36', '5.34', '5.30', '5.26']
+        perl: ['5.42', '5.40', '5.38']
         distribution: ['default']
         include:
           - os: 'windows-latest'

--- a/exercises/concept/booking-up-for-beauty/.meta/BookingUpForBeauty.pm
+++ b/exercises/concept/booking-up-for-beauty/.meta/BookingUpForBeauty.pm
@@ -1,7 +1,5 @@
 package BookingUpForBeauty;
 
-use v5.42;
-
 use Time::Piece;
 #use Const::Fast;
 

--- a/exercises/concept/booking-up-for-beauty/.meta/BookingUpForBeauty.pm
+++ b/exercises/concept/booking-up-for-beauty/.meta/BookingUpForBeauty.pm
@@ -1,6 +1,6 @@
 package BookingUpForBeauty;
 
-use v5.40;
+use v5.42;
 
 use Time::Piece;
 #use Const::Fast;

--- a/exercises/concept/booking-up-for-beauty/lib/BookingUpForBeauty.pm
+++ b/exercises/concept/booking-up-for-beauty/lib/BookingUpForBeauty.pm
@@ -1,6 +1,6 @@
 package BookingUpForBeauty;
 
-use v5.40;
+use v5.42;
 
 # Suggested datetime modules you can use:
 #use Time::Piece;

--- a/exercises/concept/booking-up-for-beauty/lib/BookingUpForBeauty.pm
+++ b/exercises/concept/booking-up-for-beauty/lib/BookingUpForBeauty.pm
@@ -1,7 +1,5 @@
 package BookingUpForBeauty;
 
-use v5.42;
-
 # Suggested datetime modules you can use:
 #use Time::Piece;
 #use DateTime::Tiny;

--- a/exercises/concept/high-score-board/.meta/HighScoreBoard.pm
+++ b/exercises/concept/high-score-board/.meta/HighScoreBoard.pm
@@ -1,6 +1,6 @@
 package HighScoreBoard;
 
-use v5.40;
+use v5.42;
 
 our %Scores;
 

--- a/exercises/concept/high-score-board/.meta/HighScoreBoard.pm
+++ b/exercises/concept/high-score-board/.meta/HighScoreBoard.pm
@@ -1,7 +1,5 @@
 package HighScoreBoard;
 
-use v5.42;
-
 our %Scores;
 
 sub set_player_scores (%new_scores) {

--- a/exercises/concept/high-score-board/lib/HighScoreBoard.pm
+++ b/exercises/concept/high-score-board/lib/HighScoreBoard.pm
@@ -1,6 +1,6 @@
 package HighScoreBoard;
 
-use v5.40;
+use v5.42;
 
 our %Scores;
 

--- a/exercises/concept/high-score-board/lib/HighScoreBoard.pm
+++ b/exercises/concept/high-score-board/lib/HighScoreBoard.pm
@@ -1,7 +1,5 @@
 package HighScoreBoard;
 
-use v5.42;
-
 our %Scores;
 
 sub set_player_scores (%new_scores) {

--- a/exercises/concept/inventory-management/.meta/InventoryManagement.pm
+++ b/exercises/concept/inventory-management/.meta/InventoryManagement.pm
@@ -1,7 +1,5 @@
 package InventoryManagement;
 
-use v5.42;
-
 sub create_inventory ($items) {
     my %inventory;
     for ( $items->@* ) {

--- a/exercises/concept/inventory-management/.meta/InventoryManagement.pm
+++ b/exercises/concept/inventory-management/.meta/InventoryManagement.pm
@@ -1,6 +1,6 @@
 package InventoryManagement;
 
-use v5.40;
+use v5.42;
 
 sub create_inventory ($items) {
     my %inventory;

--- a/exercises/concept/inventory-management/lib/InventoryManagement.pm
+++ b/exercises/concept/inventory-management/lib/InventoryManagement.pm
@@ -1,7 +1,5 @@
 package InventoryManagement;
 
-use v5.42;
-
 sub create_inventory ($items) {
     my %inventory;
     return \%inventory;

--- a/exercises/concept/inventory-management/lib/InventoryManagement.pm
+++ b/exercises/concept/inventory-management/lib/InventoryManagement.pm
@@ -1,6 +1,6 @@
 package InventoryManagement;
 
-use v5.40;
+use v5.42;
 
 sub create_inventory ($items) {
     my %inventory;

--- a/exercises/concept/language-list/.meta/LanguageList.pm
+++ b/exercises/concept/language-list/.meta/LanguageList.pm
@@ -1,6 +1,6 @@
 package LanguageList;
 
-use v5.40;
+use v5.42;
 use List::Util qw<any>;
 
 our @Languages;

--- a/exercises/concept/language-list/.meta/LanguageList.pm
+++ b/exercises/concept/language-list/.meta/LanguageList.pm
@@ -1,6 +1,5 @@
 package LanguageList;
 
-use v5.42;
 use List::Util qw<any>;
 
 our @Languages;

--- a/exercises/concept/language-list/lib/LanguageList.pm
+++ b/exercises/concept/language-list/lib/LanguageList.pm
@@ -1,6 +1,6 @@
 package LanguageList;
 
-use v5.40;
+use v5.42;
 
 our @Languages;
 

--- a/exercises/concept/language-list/lib/LanguageList.pm
+++ b/exercises/concept/language-list/lib/LanguageList.pm
@@ -1,7 +1,5 @@
 package LanguageList;
 
-use v5.42;
-
 our @Languages;
 
 sub add_language ($language) {

--- a/exercises/concept/lasagna/.meta/Lasagna.pm
+++ b/exercises/concept/lasagna/.meta/Lasagna.pm
@@ -1,7 +1,5 @@
 package Lasagna;
 
-use v5.42;
-
 our $ExpectedMinutesInOven = 40;
 
 sub remaining_minutes_in_oven ($actual_minutes_in_oven) {

--- a/exercises/concept/lasagna/.meta/Lasagna.pm
+++ b/exercises/concept/lasagna/.meta/Lasagna.pm
@@ -1,6 +1,6 @@
 package Lasagna;
 
-use v5.40;
+use v5.42;
 
 our $ExpectedMinutesInOven = 40;
 

--- a/exercises/concept/lasagna/lib/Lasagna.pm
+++ b/exercises/concept/lasagna/lib/Lasagna.pm
@@ -1,7 +1,5 @@
 package Lasagna;
 
-use v5.42;
-
 our $ExpectedMinutesInOven = undef;
 
 sub remaining_minutes_in_oven ($actual_minutes_in_oven) {

--- a/exercises/concept/lasagna/lib/Lasagna.pm
+++ b/exercises/concept/lasagna/lib/Lasagna.pm
@@ -1,6 +1,6 @@
 package Lasagna;
 
-use v5.40;
+use v5.42;
 
 our $ExpectedMinutesInOven = undef;
 

--- a/exercises/practice/accumulate/lib/Accumulate.pm
+++ b/exercises/practice/accumulate/lib/Accumulate.pm
@@ -1,7 +1,5 @@
 package Accumulate;
 
-use v5.42;
-
 use Exporter qw<import>;
 our @EXPORT_OK = qw<accumulate>;
 

--- a/exercises/practice/accumulate/lib/Accumulate.pm
+++ b/exercises/practice/accumulate/lib/Accumulate.pm
@@ -1,6 +1,6 @@
 package Accumulate;
 
-use v5.40;
+use v5.42;
 
 use Exporter qw<import>;
 our @EXPORT_OK = qw<accumulate>;

--- a/exercises/practice/acronym/lib/Acronym.pm
+++ b/exercises/practice/acronym/lib/Acronym.pm
@@ -1,7 +1,5 @@
 package Acronym;
 
-use v5.42;
-
 use Exporter qw<import>;
 our @EXPORT_OK = qw<abbreviate>;
 

--- a/exercises/practice/acronym/lib/Acronym.pm
+++ b/exercises/practice/acronym/lib/Acronym.pm
@@ -1,6 +1,6 @@
 package Acronym;
 
-use v5.40;
+use v5.42;
 
 use Exporter qw<import>;
 our @EXPORT_OK = qw<abbreviate>;

--- a/exercises/practice/affine-cipher/lib/AffineCipher.pm
+++ b/exercises/practice/affine-cipher/lib/AffineCipher.pm
@@ -1,7 +1,5 @@
 package AffineCipher;
 
-use v5.42;
-
 use Exporter qw<import>;
 our @EXPORT_OK = qw<encode decode>;
 

--- a/exercises/practice/affine-cipher/lib/AffineCipher.pm
+++ b/exercises/practice/affine-cipher/lib/AffineCipher.pm
@@ -1,6 +1,6 @@
 package AffineCipher;
 
-use v5.40;
+use v5.42;
 
 use Exporter qw<import>;
 our @EXPORT_OK = qw<encode decode>;

--- a/exercises/practice/all-your-base/lib/AllYourBase.pm
+++ b/exercises/practice/all-your-base/lib/AllYourBase.pm
@@ -1,6 +1,6 @@
 package AllYourBase;
 
-use v5.40;
+use v5.42;
 
 use Exporter qw<import>;
 our @EXPORT_OK = qw<rebase>;

--- a/exercises/practice/all-your-base/lib/AllYourBase.pm
+++ b/exercises/practice/all-your-base/lib/AllYourBase.pm
@@ -1,7 +1,5 @@
 package AllYourBase;
 
-use v5.42;
-
 use Exporter qw<import>;
 our @EXPORT_OK = qw<rebase>;
 

--- a/exercises/practice/allergies/lib/Allergies.pm
+++ b/exercises/practice/allergies/lib/Allergies.pm
@@ -1,6 +1,6 @@
 package Allergies;
 
-use v5.40;
+use v5.42;
 
 use Exporter qw<import>;
 our @EXPORT_OK = qw<allergic_to list_allergies>;

--- a/exercises/practice/allergies/lib/Allergies.pm
+++ b/exercises/practice/allergies/lib/Allergies.pm
@@ -1,7 +1,5 @@
 package Allergies;
 
-use v5.42;
-
 use Exporter qw<import>;
 our @EXPORT_OK = qw<allergic_to list_allergies>;
 

--- a/exercises/practice/anagram/lib/Anagram.pm
+++ b/exercises/practice/anagram/lib/Anagram.pm
@@ -1,6 +1,6 @@
 package Anagram;
 
-use v5.40;
+use v5.42;
 
 use Exporter qw<import>;
 our @EXPORT_OK = qw<match_anagrams>;

--- a/exercises/practice/anagram/lib/Anagram.pm
+++ b/exercises/practice/anagram/lib/Anagram.pm
@@ -1,7 +1,5 @@
 package Anagram;
 
-use v5.42;
-
 use Exporter qw<import>;
 our @EXPORT_OK = qw<match_anagrams>;
 

--- a/exercises/practice/armstrong-numbers/lib/ArmstrongNumbers.pm
+++ b/exercises/practice/armstrong-numbers/lib/ArmstrongNumbers.pm
@@ -1,7 +1,5 @@
 package ArmstrongNumbers;
 
-use v5.42;
-
 use Exporter qw<import>;
 our @EXPORT_OK = qw<is_armstrong_number>;
 

--- a/exercises/practice/armstrong-numbers/lib/ArmstrongNumbers.pm
+++ b/exercises/practice/armstrong-numbers/lib/ArmstrongNumbers.pm
@@ -1,6 +1,6 @@
 package ArmstrongNumbers;
 
-use v5.40;
+use v5.42;
 
 use Exporter qw<import>;
 our @EXPORT_OK = qw<is_armstrong_number>;

--- a/exercises/practice/atbash-cipher/lib/AtbashCipher.pm
+++ b/exercises/practice/atbash-cipher/lib/AtbashCipher.pm
@@ -1,7 +1,5 @@
 package AtbashCipher;
 
-use v5.42;
-
 use Exporter qw<import>;
 our @EXPORT_OK = qw<encode_atbash decode_atbash>;
 

--- a/exercises/practice/atbash-cipher/lib/AtbashCipher.pm
+++ b/exercises/practice/atbash-cipher/lib/AtbashCipher.pm
@@ -1,6 +1,6 @@
 package AtbashCipher;
 
-use v5.40;
+use v5.42;
 
 use Exporter qw<import>;
 our @EXPORT_OK = qw<encode_atbash decode_atbash>;

--- a/exercises/practice/binary-search-tree/lib/BinarySearchTree.pm
+++ b/exercises/practice/binary-search-tree/lib/BinarySearchTree.pm
@@ -1,4 +1,4 @@
-use v5.40;
+use v5.42;
 use experimental qw<class>;
 
 class BinarySearchTree;

--- a/exercises/practice/binary-search-tree/lib/BinarySearchTree.pm
+++ b/exercises/practice/binary-search-tree/lib/BinarySearchTree.pm
@@ -1,4 +1,3 @@
-use v5.42;
 use experimental qw<class>;
 
 class BinarySearchTree;

--- a/exercises/practice/binary-search/lib/BinarySearch.pm
+++ b/exercises/practice/binary-search/lib/BinarySearch.pm
@@ -1,6 +1,6 @@
 package BinarySearch;
 
-use v5.40;
+use v5.42;
 
 use Exporter qw<import>;
 our @EXPORT_OK = qw<binary_search>;

--- a/exercises/practice/binary-search/lib/BinarySearch.pm
+++ b/exercises/practice/binary-search/lib/BinarySearch.pm
@@ -1,7 +1,5 @@
 package BinarySearch;
 
-use v5.42;
-
 use Exporter qw<import>;
 our @EXPORT_OK = qw<binary_search>;
 

--- a/exercises/practice/bob/lib/Bob.pm
+++ b/exercises/practice/bob/lib/Bob.pm
@@ -1,8 +1,6 @@
 # Declare package 'Bob'
 package Bob;
 
-use v5.42;
-
 use Exporter qw<import>;
 our @EXPORT_OK = qw<hey>;
 

--- a/exercises/practice/bob/lib/Bob.pm
+++ b/exercises/practice/bob/lib/Bob.pm
@@ -1,7 +1,7 @@
 # Declare package 'Bob'
 package Bob;
 
-use v5.40;
+use v5.42;
 
 use Exporter qw<import>;
 our @EXPORT_OK = qw<hey>;

--- a/exercises/practice/bottle-song/lib/BottleSong.pm
+++ b/exercises/practice/bottle-song/lib/BottleSong.pm
@@ -1,7 +1,5 @@
 package BottleSong;
 
-use v5.42;
-
 use Exporter qw<import>;
 our @EXPORT_OK = qw<sing>;
 

--- a/exercises/practice/bottle-song/lib/BottleSong.pm
+++ b/exercises/practice/bottle-song/lib/BottleSong.pm
@@ -1,6 +1,6 @@
 package BottleSong;
 
-use v5.40;
+use v5.42;
 
 use Exporter qw<import>;
 our @EXPORT_OK = qw<sing>;

--- a/exercises/practice/circular-buffer/lib/CircularBuffer.pm
+++ b/exercises/practice/circular-buffer/lib/CircularBuffer.pm
@@ -1,4 +1,3 @@
-use v5.42;
 use experimental qw<class>;
 
 class CircularBuffer;

--- a/exercises/practice/circular-buffer/lib/CircularBuffer.pm
+++ b/exercises/practice/circular-buffer/lib/CircularBuffer.pm
@@ -1,4 +1,4 @@
-use v5.40;
+use v5.42;
 use experimental qw<class>;
 
 class CircularBuffer;

--- a/exercises/practice/clock/lib/Clock.pm
+++ b/exercises/practice/clock/lib/Clock.pm
@@ -1,4 +1,4 @@
-use v5.40;
+use v5.42;
 use experimental qw<class>;
 
 class Clock;

--- a/exercises/practice/clock/lib/Clock.pm
+++ b/exercises/practice/clock/lib/Clock.pm
@@ -1,4 +1,3 @@
-use v5.42;
 use experimental qw<class>;
 
 class Clock;

--- a/exercises/practice/collatz-conjecture/lib/CollatzConjecture.pm
+++ b/exercises/practice/collatz-conjecture/lib/CollatzConjecture.pm
@@ -1,6 +1,6 @@
 package CollatzConjecture;
 
-use v5.40;
+use v5.42;
 
 use Exporter qw<import>;
 our @EXPORT_OK = qw<steps>;

--- a/exercises/practice/collatz-conjecture/lib/CollatzConjecture.pm
+++ b/exercises/practice/collatz-conjecture/lib/CollatzConjecture.pm
@@ -1,7 +1,5 @@
 package CollatzConjecture;
 
-use v5.42;
-
 use Exporter qw<import>;
 our @EXPORT_OK = qw<steps>;
 

--- a/exercises/practice/crypto-square/lib/CryptoSquare.pm
+++ b/exercises/practice/crypto-square/lib/CryptoSquare.pm
@@ -1,7 +1,5 @@
 package CryptoSquare;
 
-use v5.42;
-
 use Exporter qw<import>;
 our @EXPORT_OK = qw<cipher>;
 

--- a/exercises/practice/crypto-square/lib/CryptoSquare.pm
+++ b/exercises/practice/crypto-square/lib/CryptoSquare.pm
@@ -1,6 +1,6 @@
 package CryptoSquare;
 
-use v5.40;
+use v5.42;
 
 use Exporter qw<import>;
 our @EXPORT_OK = qw<cipher>;

--- a/exercises/practice/custom-set/lib/CustomSet.pm
+++ b/exercises/practice/custom-set/lib/CustomSet.pm
@@ -1,4 +1,4 @@
-use v5.40;
+use v5.42;
 use experimental qw<class>;
 
 class CustomSet;

--- a/exercises/practice/custom-set/lib/CustomSet.pm
+++ b/exercises/practice/custom-set/lib/CustomSet.pm
@@ -1,4 +1,3 @@
-use v5.42;
 use experimental qw<class>;
 
 class CustomSet;

--- a/exercises/practice/darts/lib/Darts.pm
+++ b/exercises/practice/darts/lib/Darts.pm
@@ -1,7 +1,5 @@
 package Darts;
 
-use v5.42;
-
 use Exporter qw<import>;
 our @EXPORT_OK = qw<score_dart>;
 

--- a/exercises/practice/darts/lib/Darts.pm
+++ b/exercises/practice/darts/lib/Darts.pm
@@ -1,6 +1,6 @@
 package Darts;
 
-use v5.40;
+use v5.42;
 
 use Exporter qw<import>;
 our @EXPORT_OK = qw<score_dart>;

--- a/exercises/practice/difference-of-squares/lib/DifferenceOfSquares.pm
+++ b/exercises/practice/difference-of-squares/lib/DifferenceOfSquares.pm
@@ -1,6 +1,6 @@
 package DifferenceOfSquares;
 
-use v5.40;
+use v5.42;
 
 use Exporter qw<import>;
 our @EXPORT_OK = qw<square_of_sum sum_of_squares difference_of_squares>;

--- a/exercises/practice/difference-of-squares/lib/DifferenceOfSquares.pm
+++ b/exercises/practice/difference-of-squares/lib/DifferenceOfSquares.pm
@@ -1,7 +1,5 @@
 package DifferenceOfSquares;
 
-use v5.42;
-
 use Exporter qw<import>;
 our @EXPORT_OK = qw<square_of_sum sum_of_squares difference_of_squares>;
 

--- a/exercises/practice/dnd-character/lib/DndCharacter.pm
+++ b/exercises/practice/dnd-character/lib/DndCharacter.pm
@@ -1,4 +1,3 @@
-use v5.42;
 use experimental qw<class>;
 
 class DndCharacter;

--- a/exercises/practice/dnd-character/lib/DndCharacter.pm
+++ b/exercises/practice/dnd-character/lib/DndCharacter.pm
@@ -1,4 +1,4 @@
-use v5.40;
+use v5.42;
 use experimental qw<class>;
 
 class DndCharacter;

--- a/exercises/practice/eliuds-eggs/lib/EliudsEggs.pm
+++ b/exercises/practice/eliuds-eggs/lib/EliudsEggs.pm
@@ -1,6 +1,6 @@
 package EliudsEggs;
 
-use v5.40;
+use v5.42;
 
 use Exporter qw<import>;
 our @EXPORT_OK = qw<egg_count>;

--- a/exercises/practice/eliuds-eggs/lib/EliudsEggs.pm
+++ b/exercises/practice/eliuds-eggs/lib/EliudsEggs.pm
@@ -1,7 +1,5 @@
 package EliudsEggs;
 
-use v5.42;
-
 use Exporter qw<import>;
 our @EXPORT_OK = qw<egg_count>;
 

--- a/exercises/practice/etl/lib/ETL.pm
+++ b/exercises/practice/etl/lib/ETL.pm
@@ -1,6 +1,6 @@
 package ETL;
 
-use v5.40;
+use v5.42;
 
 use Exporter qw<import>;
 our @EXPORT_OK = qw<transform>;

--- a/exercises/practice/etl/lib/ETL.pm
+++ b/exercises/practice/etl/lib/ETL.pm
@@ -1,7 +1,5 @@
 package ETL;
 
-use v5.42;
-
 use Exporter qw<import>;
 our @EXPORT_OK = qw<transform>;
 

--- a/exercises/practice/food-chain/lib/FoodChain.pm
+++ b/exercises/practice/food-chain/lib/FoodChain.pm
@@ -1,6 +1,6 @@
 package FoodChain;
 
-use v5.40;
+use v5.42;
 
 use Exporter qw<import>;
 our @EXPORT_OK = qw<recite>;

--- a/exercises/practice/food-chain/lib/FoodChain.pm
+++ b/exercises/practice/food-chain/lib/FoodChain.pm
@@ -1,7 +1,5 @@
 package FoodChain;
 
-use v5.42;
-
 use Exporter qw<import>;
 our @EXPORT_OK = qw<recite>;
 

--- a/exercises/practice/gigasecond/lib/Gigasecond.pm
+++ b/exercises/practice/gigasecond/lib/Gigasecond.pm
@@ -1,7 +1,5 @@
 package Gigasecond;
 
-use v5.42;
-
 use Exporter qw<import>;
 our @EXPORT_OK = qw<add_gigasecond>;
 

--- a/exercises/practice/gigasecond/lib/Gigasecond.pm
+++ b/exercises/practice/gigasecond/lib/Gigasecond.pm
@@ -1,6 +1,6 @@
 package Gigasecond;
 
-use v5.40;
+use v5.42;
 
 use Exporter qw<import>;
 our @EXPORT_OK = qw<add_gigasecond>;

--- a/exercises/practice/grade-school/lib/GradeSchool.pm
+++ b/exercises/practice/grade-school/lib/GradeSchool.pm
@@ -1,4 +1,4 @@
-use v5.40;
+use v5.42;
 use experimental qw<class>;
 
 class GradeSchool;

--- a/exercises/practice/grade-school/lib/GradeSchool.pm
+++ b/exercises/practice/grade-school/lib/GradeSchool.pm
@@ -1,4 +1,3 @@
-use v5.42;
 use experimental qw<class>;
 
 class GradeSchool;

--- a/exercises/practice/grains/lib/Grains.pm
+++ b/exercises/practice/grains/lib/Grains.pm
@@ -1,6 +1,6 @@
 package Grains;
 
-use v5.40;
+use v5.42;
 
 use Exporter qw<import>;
 our @EXPORT_OK = qw<grains_on_square total_grains>;

--- a/exercises/practice/grains/lib/Grains.pm
+++ b/exercises/practice/grains/lib/Grains.pm
@@ -1,7 +1,5 @@
 package Grains;
 
-use v5.42;
-
 use Exporter qw<import>;
 our @EXPORT_OK = qw<grains_on_square total_grains>;
 

--- a/exercises/practice/hamming/lib/Hamming.pm
+++ b/exercises/practice/hamming/lib/Hamming.pm
@@ -1,6 +1,6 @@
 package Hamming;
 
-use v5.40;
+use v5.42;
 
 use Exporter qw<import>;
 our @EXPORT_OK = qw<hamming_distance>;

--- a/exercises/practice/hamming/lib/Hamming.pm
+++ b/exercises/practice/hamming/lib/Hamming.pm
@@ -1,7 +1,5 @@
 package Hamming;
 
-use v5.42;
-
 use Exporter qw<import>;
 our @EXPORT_OK = qw<hamming_distance>;
 

--- a/exercises/practice/hello-world/lib/HelloWorld.pm
+++ b/exercises/practice/hello-world/lib/HelloWorld.pm
@@ -1,7 +1,7 @@
 # Declare package 'HelloWorld'
 package HelloWorld;
 
-use v5.40;
+use v5.42;
 
 use Exporter qw<import>;
 our @EXPORT_OK = qw<hello>;

--- a/exercises/practice/hello-world/lib/HelloWorld.pm
+++ b/exercises/practice/hello-world/lib/HelloWorld.pm
@@ -1,8 +1,6 @@
 # Declare package 'HelloWorld'
 package HelloWorld;
 
-use v5.42;
-
 use Exporter qw<import>;
 our @EXPORT_OK = qw<hello>;
 

--- a/exercises/practice/house/lib/House.pm
+++ b/exercises/practice/house/lib/House.pm
@@ -1,6 +1,6 @@
 package House;
 
-use v5.40;
+use v5.42;
 
 use Exporter qw<import>;
 our @EXPORT_OK = qw<recite>;

--- a/exercises/practice/house/lib/House.pm
+++ b/exercises/practice/house/lib/House.pm
@@ -1,7 +1,5 @@
 package House;
 
-use v5.42;
-
 use Exporter qw<import>;
 our @EXPORT_OK = qw<recite>;
 

--- a/exercises/practice/isogram/lib/Isogram.pm
+++ b/exercises/practice/isogram/lib/Isogram.pm
@@ -1,6 +1,6 @@
 package Isogram;
 
-use v5.40;
+use v5.42;
 
 use Exporter qw<import>;
 our @EXPORT_OK = qw<is_isogram>;

--- a/exercises/practice/isogram/lib/Isogram.pm
+++ b/exercises/practice/isogram/lib/Isogram.pm
@@ -1,7 +1,5 @@
 package Isogram;
 
-use v5.42;
-
 use Exporter qw<import>;
 our @EXPORT_OK = qw<is_isogram>;
 

--- a/exercises/practice/kindergarten-garden/lib/KindergartenGarden.pm
+++ b/exercises/practice/kindergarten-garden/lib/KindergartenGarden.pm
@@ -1,7 +1,5 @@
 package KindergartenGarden;
 
-use v5.42;
-
 use Exporter qw<import>;
 our @EXPORT_OK = qw<plants>;
 

--- a/exercises/practice/kindergarten-garden/lib/KindergartenGarden.pm
+++ b/exercises/practice/kindergarten-garden/lib/KindergartenGarden.pm
@@ -1,6 +1,6 @@
 package KindergartenGarden;
 
-use v5.40;
+use v5.42;
 
 use Exporter qw<import>;
 our @EXPORT_OK = qw<plants>;

--- a/exercises/practice/knapsack/lib/Knapsack.pm
+++ b/exercises/practice/knapsack/lib/Knapsack.pm
@@ -1,7 +1,5 @@
 package Knapsack;
 
-use v5.42;
-
 use Exporter qw<import>;
 our @EXPORT_OK = qw<maximum_value>;
 

--- a/exercises/practice/knapsack/lib/Knapsack.pm
+++ b/exercises/practice/knapsack/lib/Knapsack.pm
@@ -1,6 +1,6 @@
 package Knapsack;
 
-use v5.40;
+use v5.42;
 
 use Exporter qw<import>;
 our @EXPORT_OK = qw<maximum_value>;

--- a/exercises/practice/largest-series-product/lib/LargestSeriesProduct.pm
+++ b/exercises/practice/largest-series-product/lib/LargestSeriesProduct.pm
@@ -1,6 +1,6 @@
 package LargestSeriesProduct;
 
-use v5.40;
+use v5.42;
 
 use Exporter qw<import>;
 our @EXPORT_OK = qw<largest_product>;

--- a/exercises/practice/largest-series-product/lib/LargestSeriesProduct.pm
+++ b/exercises/practice/largest-series-product/lib/LargestSeriesProduct.pm
@@ -1,7 +1,5 @@
 package LargestSeriesProduct;
 
-use v5.42;
-
 use Exporter qw<import>;
 our @EXPORT_OK = qw<largest_product>;
 

--- a/exercises/practice/leap/lib/Leap.pm
+++ b/exercises/practice/leap/lib/Leap.pm
@@ -1,7 +1,7 @@
 # Declare package 'Leap'
 package Leap;
 
-use v5.40;
+use v5.42;
 
 use Exporter qw<import>;
 our @EXPORT_OK = qw<is_leap_year>;

--- a/exercises/practice/leap/lib/Leap.pm
+++ b/exercises/practice/leap/lib/Leap.pm
@@ -1,8 +1,6 @@
 # Declare package 'Leap'
 package Leap;
 
-use v5.42;
-
 use Exporter qw<import>;
 our @EXPORT_OK = qw<is_leap_year>;
 

--- a/exercises/practice/list-ops/lib/ListOps.pm
+++ b/exercises/practice/list-ops/lib/ListOps.pm
@@ -1,6 +1,6 @@
 package ListOps;
 
-use v5.40;
+use v5.42;
 
 sub append ( $list1, $list2 ) {
     return undef;

--- a/exercises/practice/list-ops/lib/ListOps.pm
+++ b/exercises/practice/list-ops/lib/ListOps.pm
@@ -1,7 +1,5 @@
 package ListOps;
 
-use v5.42;
-
 sub append ( $list1, $list2 ) {
     return undef;
 }

--- a/exercises/practice/luhn/lib/Luhn.pm
+++ b/exercises/practice/luhn/lib/Luhn.pm
@@ -1,6 +1,6 @@
 package Luhn;
 
-use v5.40;
+use v5.42;
 
 use Exporter qw<import>;
 our @EXPORT_OK = qw<is_luhn_valid>;

--- a/exercises/practice/luhn/lib/Luhn.pm
+++ b/exercises/practice/luhn/lib/Luhn.pm
@@ -1,7 +1,5 @@
 package Luhn;
 
-use v5.42;
-
 use Exporter qw<import>;
 our @EXPORT_OK = qw<is_luhn_valid>;
 

--- a/exercises/practice/matching-brackets/lib/MatchingBrackets.pm
+++ b/exercises/practice/matching-brackets/lib/MatchingBrackets.pm
@@ -1,7 +1,5 @@
 package MatchingBrackets;
 
-use v5.42;
-
 use Exporter qw<import>;
 our @EXPORT_OK = qw<has_matching_brackets>;
 

--- a/exercises/practice/matching-brackets/lib/MatchingBrackets.pm
+++ b/exercises/practice/matching-brackets/lib/MatchingBrackets.pm
@@ -1,6 +1,6 @@
 package MatchingBrackets;
 
-use v5.40;
+use v5.42;
 
 use Exporter qw<import>;
 our @EXPORT_OK = qw<has_matching_brackets>;

--- a/exercises/practice/matrix/lib/Matrix.pm
+++ b/exercises/practice/matrix/lib/Matrix.pm
@@ -1,6 +1,6 @@
 package Matrix;
 
-use v5.40;
+use v5.42;
 
 use Exporter qw<import>;
 our @EXPORT_OK = qw<extract_row extract_column>;

--- a/exercises/practice/matrix/lib/Matrix.pm
+++ b/exercises/practice/matrix/lib/Matrix.pm
@@ -1,7 +1,5 @@
 package Matrix;
 
-use v5.42;
-
 use Exporter qw<import>;
 our @EXPORT_OK = qw<extract_row extract_column>;
 

--- a/exercises/practice/meetup/lib/Meetup.pm
+++ b/exercises/practice/meetup/lib/Meetup.pm
@@ -1,7 +1,5 @@
 package Meetup;
 
-use v5.42;
-
 use Exporter qw<import>;
 our @EXPORT_OK = qw<meetup>;
 

--- a/exercises/practice/meetup/lib/Meetup.pm
+++ b/exercises/practice/meetup/lib/Meetup.pm
@@ -1,6 +1,6 @@
 package Meetup;
 
-use v5.40;
+use v5.42;
 
 use Exporter qw<import>;
 our @EXPORT_OK = qw<meetup>;

--- a/exercises/practice/micro-blog/lib/MicroBlog.pm
+++ b/exercises/practice/micro-blog/lib/MicroBlog.pm
@@ -1,7 +1,5 @@
 package MicroBlog;
 
-use v5.42;
-
 use Exporter qw<import>;
 our @EXPORT_OK = qw<truncate_post>;
 

--- a/exercises/practice/micro-blog/lib/MicroBlog.pm
+++ b/exercises/practice/micro-blog/lib/MicroBlog.pm
@@ -1,6 +1,6 @@
 package MicroBlog;
 
-use v5.40;
+use v5.42;
 
 use Exporter qw<import>;
 our @EXPORT_OK = qw<truncate_post>;

--- a/exercises/practice/minesweeper/lib/Minesweeper.pm
+++ b/exercises/practice/minesweeper/lib/Minesweeper.pm
@@ -1,7 +1,5 @@
 package Minesweeper;
 
-use v5.42;
-
 use Exporter qw<import>;
 our @EXPORT_OK = qw<annotate>;
 

--- a/exercises/practice/minesweeper/lib/Minesweeper.pm
+++ b/exercises/practice/minesweeper/lib/Minesweeper.pm
@@ -1,6 +1,6 @@
 package Minesweeper;
 
-use v5.40;
+use v5.42;
 
 use Exporter qw<import>;
 our @EXPORT_OK = qw<annotate>;

--- a/exercises/practice/nucleotide-count/lib/NucleotideCount.pm
+++ b/exercises/practice/nucleotide-count/lib/NucleotideCount.pm
@@ -1,7 +1,5 @@
 package NucleotideCount;
 
-use v5.42;
-
 use Exporter qw<import>;
 our @EXPORT_OK = qw<count_nucleotides>;
 

--- a/exercises/practice/nucleotide-count/lib/NucleotideCount.pm
+++ b/exercises/practice/nucleotide-count/lib/NucleotideCount.pm
@@ -1,6 +1,6 @@
 package NucleotideCount;
 
-use v5.40;
+use v5.42;
 
 use Exporter qw<import>;
 our @EXPORT_OK = qw<count_nucleotides>;

--- a/exercises/practice/ocr-numbers/lib/OCRNumbers.pm
+++ b/exercises/practice/ocr-numbers/lib/OCRNumbers.pm
@@ -1,7 +1,5 @@
 package OCRNumbers;
 
-use v5.42;
-
 use Exporter qw<import>;
 our @EXPORT_OK = qw<convert_ocr>;
 

--- a/exercises/practice/ocr-numbers/lib/OCRNumbers.pm
+++ b/exercises/practice/ocr-numbers/lib/OCRNumbers.pm
@@ -1,6 +1,6 @@
 package OCRNumbers;
 
-use v5.40;
+use v5.42;
 
 use Exporter qw<import>;
 our @EXPORT_OK = qw<convert_ocr>;

--- a/exercises/practice/palindrome-products/lib/PalindromeProducts.pm
+++ b/exercises/practice/palindrome-products/lib/PalindromeProducts.pm
@@ -1,7 +1,5 @@
 package PalindromeProducts;
 
-use v5.42;
-
 use Exporter qw<import>;
 our @EXPORT_OK = qw<smallest_palindrome largest_palindrome>;
 

--- a/exercises/practice/palindrome-products/lib/PalindromeProducts.pm
+++ b/exercises/practice/palindrome-products/lib/PalindromeProducts.pm
@@ -1,6 +1,6 @@
 package PalindromeProducts;
 
-use v5.40;
+use v5.42;
 
 use Exporter qw<import>;
 our @EXPORT_OK = qw<smallest_palindrome largest_palindrome>;

--- a/exercises/practice/pangram/lib/Pangram.pm
+++ b/exercises/practice/pangram/lib/Pangram.pm
@@ -1,6 +1,6 @@
 package Pangram;
 
-use v5.40;
+use v5.42;
 
 use Exporter qw<import>;
 our @EXPORT_OK = qw<is_pangram>;

--- a/exercises/practice/pangram/lib/Pangram.pm
+++ b/exercises/practice/pangram/lib/Pangram.pm
@@ -1,7 +1,5 @@
 package Pangram;
 
-use v5.42;
-
 use Exporter qw<import>;
 our @EXPORT_OK = qw<is_pangram>;
 

--- a/exercises/practice/pascals-triangle/lib/PascalsTriangle.pm
+++ b/exercises/practice/pascals-triangle/lib/PascalsTriangle.pm
@@ -1,6 +1,6 @@
 package PascalsTriangle;
 
-use v5.40;
+use v5.42;
 
 use Exporter qw<import>;
 our @EXPORT_OK = qw<pascal_rows>;

--- a/exercises/practice/pascals-triangle/lib/PascalsTriangle.pm
+++ b/exercises/practice/pascals-triangle/lib/PascalsTriangle.pm
@@ -1,7 +1,5 @@
 package PascalsTriangle;
 
-use v5.42;
-
 use Exporter qw<import>;
 our @EXPORT_OK = qw<pascal_rows>;
 

--- a/exercises/practice/phone-number/lib/PhoneNumber.pm
+++ b/exercises/practice/phone-number/lib/PhoneNumber.pm
@@ -1,7 +1,5 @@
 package PhoneNumber;
 
-use v5.42;
-
 use Exporter qw<import>;
 our @EXPORT_OK = qw<clean_number>;
 

--- a/exercises/practice/phone-number/lib/PhoneNumber.pm
+++ b/exercises/practice/phone-number/lib/PhoneNumber.pm
@@ -1,6 +1,6 @@
 package PhoneNumber;
 
-use v5.40;
+use v5.42;
 
 use Exporter qw<import>;
 our @EXPORT_OK = qw<clean_number>;

--- a/exercises/practice/pig-latin/lib/PigLatin.pm
+++ b/exercises/practice/pig-latin/lib/PigLatin.pm
@@ -1,7 +1,5 @@
 package PigLatin;
 
-use v5.42;
-
 use Exporter qw<import>;
 our @EXPORT_OK = qw<translate>;
 

--- a/exercises/practice/pig-latin/lib/PigLatin.pm
+++ b/exercises/practice/pig-latin/lib/PigLatin.pm
@@ -1,6 +1,6 @@
 package PigLatin;
 
-use v5.40;
+use v5.42;
 
 use Exporter qw<import>;
 our @EXPORT_OK = qw<translate>;

--- a/exercises/practice/prime-factors/lib/PrimeFactors.pm
+++ b/exercises/practice/prime-factors/lib/PrimeFactors.pm
@@ -1,7 +1,5 @@
 package PrimeFactors;
 
-use v5.42;
-
 use Exporter qw<import>;
 our @EXPORT_OK = qw<factors>;
 

--- a/exercises/practice/prime-factors/lib/PrimeFactors.pm
+++ b/exercises/practice/prime-factors/lib/PrimeFactors.pm
@@ -1,6 +1,6 @@
 package PrimeFactors;
 
-use v5.40;
+use v5.42;
 
 use Exporter qw<import>;
 our @EXPORT_OK = qw<factors>;

--- a/exercises/practice/proverb/lib/Proverb.pm
+++ b/exercises/practice/proverb/lib/Proverb.pm
@@ -1,6 +1,6 @@
 package Proverb;
 
-use v5.40;
+use v5.42;
 
 use Exporter qw<import>;
 our @EXPORT_OK = qw<proverb>;

--- a/exercises/practice/proverb/lib/Proverb.pm
+++ b/exercises/practice/proverb/lib/Proverb.pm
@@ -1,7 +1,5 @@
 package Proverb;
 
-use v5.42;
-
 use Exporter qw<import>;
 our @EXPORT_OK = qw<proverb>;
 

--- a/exercises/practice/pythagorean-triplet/lib/PythagoreanTriplet.pm
+++ b/exercises/practice/pythagorean-triplet/lib/PythagoreanTriplet.pm
@@ -1,6 +1,6 @@
 package PythagoreanTriplet;
 
-use v5.40;
+use v5.42;
 
 use Exporter qw<import>;
 our @EXPORT_OK = qw<triplets_with_sum>;

--- a/exercises/practice/pythagorean-triplet/lib/PythagoreanTriplet.pm
+++ b/exercises/practice/pythagorean-triplet/lib/PythagoreanTriplet.pm
@@ -1,7 +1,5 @@
 package PythagoreanTriplet;
 
-use v5.42;
-
 use Exporter qw<import>;
 our @EXPORT_OK = qw<triplets_with_sum>;
 

--- a/exercises/practice/queen-attack/lib/Queen.pm
+++ b/exercises/practice/queen-attack/lib/Queen.pm
@@ -1,4 +1,4 @@
-use v5.40;
+use v5.42;
 use experimental qw<class>;
 
 class Queen;

--- a/exercises/practice/queen-attack/lib/Queen.pm
+++ b/exercises/practice/queen-attack/lib/Queen.pm
@@ -1,4 +1,3 @@
-use v5.42;
 use experimental qw<class>;
 
 class Queen;

--- a/exercises/practice/raindrops/lib/Raindrops.pm
+++ b/exercises/practice/raindrops/lib/Raindrops.pm
@@ -1,7 +1,5 @@
 package Raindrops;
 
-use v5.42;
-
 use Exporter qw<import>;
 our @EXPORT_OK = qw<raindrop>;
 

--- a/exercises/practice/raindrops/lib/Raindrops.pm
+++ b/exercises/practice/raindrops/lib/Raindrops.pm
@@ -1,6 +1,6 @@
 package Raindrops;
 
-use v5.40;
+use v5.42;
 
 use Exporter qw<import>;
 our @EXPORT_OK = qw<raindrop>;

--- a/exercises/practice/reverse-string/lib/ReverseString.pm
+++ b/exercises/practice/reverse-string/lib/ReverseString.pm
@@ -1,7 +1,5 @@
 package ReverseString;
 
-use v5.42;
-
 use Exporter qw<import>;
 our @EXPORT_OK = qw<str_reverse>;
 

--- a/exercises/practice/reverse-string/lib/ReverseString.pm
+++ b/exercises/practice/reverse-string/lib/ReverseString.pm
@@ -1,6 +1,6 @@
 package ReverseString;
 
-use v5.40;
+use v5.42;
 
 use Exporter qw<import>;
 our @EXPORT_OK = qw<str_reverse>;

--- a/exercises/practice/rna-transcription/lib/RNA.pm
+++ b/exercises/practice/rna-transcription/lib/RNA.pm
@@ -1,6 +1,6 @@
 package RNA;
 
-use v5.40;
+use v5.42;
 
 use Exporter qw<import>;
 our @EXPORT_OK = qw<to_rna>;

--- a/exercises/practice/rna-transcription/lib/RNA.pm
+++ b/exercises/practice/rna-transcription/lib/RNA.pm
@@ -1,7 +1,5 @@
 package RNA;
 
-use v5.42;
-
 use Exporter qw<import>;
 our @EXPORT_OK = qw<to_rna>;
 

--- a/exercises/practice/robot-name/lib/RobotName.pm
+++ b/exercises/practice/robot-name/lib/RobotName.pm
@@ -1,4 +1,4 @@
-use v5.40;
+use v5.42;
 use experimental qw<class>;
 
 class RobotName;

--- a/exercises/practice/robot-name/lib/RobotName.pm
+++ b/exercises/practice/robot-name/lib/RobotName.pm
@@ -1,4 +1,3 @@
-use v5.42;
 use experimental qw<class>;
 
 class RobotName;

--- a/exercises/practice/robot-simulator/lib/Robot.pm
+++ b/exercises/practice/robot-simulator/lib/Robot.pm
@@ -1,4 +1,4 @@
-use v5.40;
+use v5.42;
 use experimental qw<class>;
 
 class Robot;

--- a/exercises/practice/robot-simulator/lib/Robot.pm
+++ b/exercises/practice/robot-simulator/lib/Robot.pm
@@ -1,4 +1,3 @@
-use v5.42;
 use experimental qw<class>;
 
 class Robot;

--- a/exercises/practice/roman-numerals/lib/RomanNumerals.pm
+++ b/exercises/practice/roman-numerals/lib/RomanNumerals.pm
@@ -1,7 +1,5 @@
 package RomanNumerals;
 
-use v5.42;
-
 use Exporter qw<import>;
 our @EXPORT_OK = qw<to_roman>;
 

--- a/exercises/practice/roman-numerals/lib/RomanNumerals.pm
+++ b/exercises/practice/roman-numerals/lib/RomanNumerals.pm
@@ -1,6 +1,6 @@
 package RomanNumerals;
 
-use v5.40;
+use v5.42;
 
 use Exporter qw<import>;
 our @EXPORT_OK = qw<to_roman>;

--- a/exercises/practice/rotational-cipher/lib/RotationalCipher.pm
+++ b/exercises/practice/rotational-cipher/lib/RotationalCipher.pm
@@ -1,6 +1,6 @@
 package RotationalCipher;
 
-use v5.40;
+use v5.42;
 
 use Exporter qw<import>;
 our @EXPORT_OK = qw<caesar_cipher>;

--- a/exercises/practice/rotational-cipher/lib/RotationalCipher.pm
+++ b/exercises/practice/rotational-cipher/lib/RotationalCipher.pm
@@ -1,7 +1,5 @@
 package RotationalCipher;
 
-use v5.42;
-
 use Exporter qw<import>;
 our @EXPORT_OK = qw<caesar_cipher>;
 

--- a/exercises/practice/run-length-encoding/lib/RunLengthEncoding.pm
+++ b/exercises/practice/run-length-encoding/lib/RunLengthEncoding.pm
@@ -1,6 +1,6 @@
 package RunLengthEncoding;
 
-use v5.40;
+use v5.42;
 
 use Exporter qw<import>;
 our @EXPORT_OK = qw<encode decode>;

--- a/exercises/practice/run-length-encoding/lib/RunLengthEncoding.pm
+++ b/exercises/practice/run-length-encoding/lib/RunLengthEncoding.pm
@@ -1,7 +1,5 @@
 package RunLengthEncoding;
 
-use v5.42;
-
 use Exporter qw<import>;
 our @EXPORT_OK = qw<encode decode>;
 

--- a/exercises/practice/saddle-points/lib/SaddlePoints.pm
+++ b/exercises/practice/saddle-points/lib/SaddlePoints.pm
@@ -1,7 +1,5 @@
 package SaddlePoints;
 
-use v5.42;
-
 use Exporter qw<import>;
 our @EXPORT_OK = qw<saddle_points>;
 

--- a/exercises/practice/saddle-points/lib/SaddlePoints.pm
+++ b/exercises/practice/saddle-points/lib/SaddlePoints.pm
@@ -1,6 +1,6 @@
 package SaddlePoints;
 
-use v5.40;
+use v5.42;
 
 use Exporter qw<import>;
 our @EXPORT_OK = qw<saddle_points>;

--- a/exercises/practice/say/lib/Say.pm
+++ b/exercises/practice/say/lib/Say.pm
@@ -1,6 +1,6 @@
 package Say;
 
-use v5.40;
+use v5.42;
 
 use Exporter qw<import>;
 our @EXPORT_OK = qw<say_number>;

--- a/exercises/practice/say/lib/Say.pm
+++ b/exercises/practice/say/lib/Say.pm
@@ -1,7 +1,5 @@
 package Say;
 
-use v5.42;
-
 use Exporter qw<import>;
 our @EXPORT_OK = qw<say_number>;
 

--- a/exercises/practice/scrabble-score/lib/Scrabble.pm
+++ b/exercises/practice/scrabble-score/lib/Scrabble.pm
@@ -1,7 +1,5 @@
 package Scrabble;
 
-use v5.42;
-
 use Exporter qw<import>;
 our @EXPORT_OK = qw<scrabble_score>;
 

--- a/exercises/practice/scrabble-score/lib/Scrabble.pm
+++ b/exercises/practice/scrabble-score/lib/Scrabble.pm
@@ -1,6 +1,6 @@
 package Scrabble;
 
-use v5.40;
+use v5.42;
 
 use Exporter qw<import>;
 our @EXPORT_OK = qw<scrabble_score>;

--- a/exercises/practice/secret-handshake/lib/SecretHandshake.pm
+++ b/exercises/practice/secret-handshake/lib/SecretHandshake.pm
@@ -1,6 +1,6 @@
 package SecretHandshake;
 
-use v5.40;
+use v5.42;
 
 use Exporter qw<import>;
 our @EXPORT_OK = qw<handshake>;

--- a/exercises/practice/secret-handshake/lib/SecretHandshake.pm
+++ b/exercises/practice/secret-handshake/lib/SecretHandshake.pm
@@ -1,7 +1,5 @@
 package SecretHandshake;
 
-use v5.42;
-
 use Exporter qw<import>;
 our @EXPORT_OK = qw<handshake>;
 

--- a/exercises/practice/series/lib/Series.pm
+++ b/exercises/practice/series/lib/Series.pm
@@ -1,7 +1,5 @@
 package Series;
 
-use v5.42;
-
 use Exporter qw<import>;
 our @EXPORT_OK = qw<slices>;
 

--- a/exercises/practice/series/lib/Series.pm
+++ b/exercises/practice/series/lib/Series.pm
@@ -1,6 +1,6 @@
 package Series;
 
-use v5.40;
+use v5.42;
 
 use Exporter qw<import>;
 our @EXPORT_OK = qw<slices>;

--- a/exercises/practice/sieve/lib/Sieve.pm
+++ b/exercises/practice/sieve/lib/Sieve.pm
@@ -1,6 +1,6 @@
 package Sieve;
 
-use v5.40;
+use v5.42;
 
 use Exporter qw<import>;
 our @EXPORT_OK = qw<find_primes>;

--- a/exercises/practice/sieve/lib/Sieve.pm
+++ b/exercises/practice/sieve/lib/Sieve.pm
@@ -1,7 +1,5 @@
 package Sieve;
 
-use v5.42;
-
 use Exporter qw<import>;
 our @EXPORT_OK = qw<find_primes>;
 

--- a/exercises/practice/simple-cipher/lib/SimpleCipher.pm
+++ b/exercises/practice/simple-cipher/lib/SimpleCipher.pm
@@ -1,4 +1,3 @@
-use v5.42;
 use experimental qw<class>;
 
 class SimpleCipher;

--- a/exercises/practice/simple-cipher/lib/SimpleCipher.pm
+++ b/exercises/practice/simple-cipher/lib/SimpleCipher.pm
@@ -1,4 +1,4 @@
-use v5.40;
+use v5.42;
 use experimental qw<class>;
 
 class SimpleCipher;

--- a/exercises/practice/space-age/lib/SpaceAge.pm
+++ b/exercises/practice/space-age/lib/SpaceAge.pm
@@ -1,7 +1,5 @@
 package SpaceAge;
 
-use v5.42;
-
 use Exporter qw<import>;
 our @EXPORT_OK = qw<age_on_planet>;
 

--- a/exercises/practice/space-age/lib/SpaceAge.pm
+++ b/exercises/practice/space-age/lib/SpaceAge.pm
@@ -1,6 +1,6 @@
 package SpaceAge;
 
-use v5.40;
+use v5.42;
 
 use Exporter qw<import>;
 our @EXPORT_OK = qw<age_on_planet>;

--- a/exercises/practice/spiral-matrix/lib/SpiralMatrix.pm
+++ b/exercises/practice/spiral-matrix/lib/SpiralMatrix.pm
@@ -1,6 +1,6 @@
 package SpiralMatrix;
 
-use v5.40;
+use v5.42;
 
 use Exporter qw<import>;
 our @EXPORT_OK = qw<spiral_matrix>;

--- a/exercises/practice/spiral-matrix/lib/SpiralMatrix.pm
+++ b/exercises/practice/spiral-matrix/lib/SpiralMatrix.pm
@@ -1,7 +1,5 @@
 package SpiralMatrix;
 
-use v5.42;
-
 use Exporter qw<import>;
 our @EXPORT_OK = qw<spiral_matrix>;
 

--- a/exercises/practice/strain/lib/Strain.pm
+++ b/exercises/practice/strain/lib/Strain.pm
@@ -1,6 +1,6 @@
 package Strain;
 
-use v5.40;
+use v5.42;
 
 use Exporter qw<import>;
 our @EXPORT_OK = qw<keep discard>;

--- a/exercises/practice/strain/lib/Strain.pm
+++ b/exercises/practice/strain/lib/Strain.pm
@@ -1,7 +1,5 @@
 package Strain;
 
-use v5.42;
-
 use Exporter qw<import>;
 our @EXPORT_OK = qw<keep discard>;
 

--- a/exercises/practice/sublist/lib/Sublist.pm
+++ b/exercises/practice/sublist/lib/Sublist.pm
@@ -1,6 +1,6 @@
 package Sublist;
 
-use v5.40;
+use v5.42;
 
 use Exporter qw<import>;
 our @EXPORT_OK = qw<compare_lists>;

--- a/exercises/practice/sublist/lib/Sublist.pm
+++ b/exercises/practice/sublist/lib/Sublist.pm
@@ -1,7 +1,5 @@
 package Sublist;
 
-use v5.42;
-
 use Exporter qw<import>;
 our @EXPORT_OK = qw<compare_lists>;
 

--- a/exercises/practice/sum-of-multiples/lib/SumOfMultiples.pm
+++ b/exercises/practice/sum-of-multiples/lib/SumOfMultiples.pm
@@ -1,7 +1,5 @@
 package SumOfMultiples;
 
-use v5.42;
-
 use Exporter qw<import>;
 our @EXPORT_OK = qw<sum_of_multiples>;
 

--- a/exercises/practice/sum-of-multiples/lib/SumOfMultiples.pm
+++ b/exercises/practice/sum-of-multiples/lib/SumOfMultiples.pm
@@ -1,6 +1,6 @@
 package SumOfMultiples;
 
-use v5.40;
+use v5.42;
 
 use Exporter qw<import>;
 our @EXPORT_OK = qw<sum_of_multiples>;

--- a/exercises/practice/triangle/lib/Triangle.pm
+++ b/exercises/practice/triangle/lib/Triangle.pm
@@ -1,7 +1,5 @@
 package Triangle;
 
-use v5.42;
-
 use Exporter qw<import>;
 our @EXPORT_OK = qw<is_equilateral is_isosceles is_scalene>;
 

--- a/exercises/practice/triangle/lib/Triangle.pm
+++ b/exercises/practice/triangle/lib/Triangle.pm
@@ -1,6 +1,6 @@
 package Triangle;
 
-use v5.40;
+use v5.42;
 
 use Exporter qw<import>;
 our @EXPORT_OK = qw<is_equilateral is_isosceles is_scalene>;

--- a/exercises/practice/twelve-days/lib/TwelveDays.pm
+++ b/exercises/practice/twelve-days/lib/TwelveDays.pm
@@ -1,6 +1,6 @@
 package TwelveDays;
 
-use v5.40;
+use v5.42;
 
 use Exporter qw<import>;
 our @EXPORT_OK = qw<recite>;

--- a/exercises/practice/twelve-days/lib/TwelveDays.pm
+++ b/exercises/practice/twelve-days/lib/TwelveDays.pm
@@ -1,7 +1,5 @@
 package TwelveDays;
 
-use v5.42;
-
 use Exporter qw<import>;
 our @EXPORT_OK = qw<recite>;
 

--- a/exercises/practice/two-bucket/lib/TwoBucket.pm
+++ b/exercises/practice/two-bucket/lib/TwoBucket.pm
@@ -1,6 +1,6 @@
 package TwoBucket;
 
-use v5.40;
+use v5.42;
 
 use Exporter qw<import>;
 our @EXPORT_OK = qw<measure>;

--- a/exercises/practice/two-bucket/lib/TwoBucket.pm
+++ b/exercises/practice/two-bucket/lib/TwoBucket.pm
@@ -1,7 +1,5 @@
 package TwoBucket;
 
-use v5.42;
-
 use Exporter qw<import>;
 our @EXPORT_OK = qw<measure>;
 

--- a/exercises/practice/two-fer/lib/TwoFer.pm
+++ b/exercises/practice/two-fer/lib/TwoFer.pm
@@ -1,7 +1,5 @@
 package TwoFer;
 
-use v5.42;
-
 use Exporter qw<import>;
 our @EXPORT_OK = qw<two_fer>;
 

--- a/exercises/practice/two-fer/lib/TwoFer.pm
+++ b/exercises/practice/two-fer/lib/TwoFer.pm
@@ -1,6 +1,6 @@
 package TwoFer;
 
-use v5.40;
+use v5.42;
 
 use Exporter qw<import>;
 our @EXPORT_OK = qw<two_fer>;

--- a/exercises/practice/word-count/lib/WordCount.pm
+++ b/exercises/practice/word-count/lib/WordCount.pm
@@ -1,7 +1,5 @@
 package WordCount;
 
-use v5.42;
-
 use Exporter qw<import>;
 our @EXPORT_OK = qw<count_words>;
 

--- a/exercises/practice/word-count/lib/WordCount.pm
+++ b/exercises/practice/word-count/lib/WordCount.pm
@@ -1,6 +1,6 @@
 package WordCount;
 
-use v5.40;
+use v5.42;
 
 use Exporter qw<import>;
 our @EXPORT_OK = qw<count_words>;

--- a/exercises/practice/wordy/lib/Wordy.pm
+++ b/exercises/practice/wordy/lib/Wordy.pm
@@ -1,6 +1,6 @@
 package Wordy;
 
-use v5.40;
+use v5.42;
 
 use Exporter qw<import>;
 our @EXPORT_OK = qw<answer>;

--- a/exercises/practice/wordy/lib/Wordy.pm
+++ b/exercises/practice/wordy/lib/Wordy.pm
@@ -1,7 +1,5 @@
 package Wordy;
 
-use v5.42;
-
 use Exporter qw<import>;
 our @EXPORT_OK = qw<answer>;
 

--- a/exercises/practice/yacht/lib/Yacht.pm
+++ b/exercises/practice/yacht/lib/Yacht.pm
@@ -1,7 +1,5 @@
 package Yacht;
 
-use v5.42;
-
 use Exporter qw<import>;
 our @EXPORT_OK = qw<score>;
 

--- a/exercises/practice/yacht/lib/Yacht.pm
+++ b/exercises/practice/yacht/lib/Yacht.pm
@@ -1,6 +1,6 @@
 package Yacht;
 
-use v5.40;
+use v5.42;
 
 use Exporter qw<import>;
 our @EXPORT_OK = qw<score>;

--- a/templates/module.mustache
+++ b/templates/module.mustache
@@ -1,7 +1,7 @@
 {{^class}}{{#package_comment}}{{&package_comment}}
 {{/package_comment}}package {{&package}};
 
-{{/class}}{{^older_perl_support}}use v5.40;{{#class}}
+{{/class}}{{^older_perl_support}}use v5.42;{{#class}}
 use experimental qw<class>;{{/class}}{{/older_perl_support}}{{#older_perl_support}}use strict;
 use warnings;
 use experimental qw<signatures postderef postderef_qq>;{{#class}}


### PR DESCRIPTION
Follows https://github.com/exercism/perl5-test-runner/pull/98 and https://github.com/exercism/perl5-analyzer/pull/46